### PR TITLE
Create recruitments controller

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,12 +1,3 @@
 class ApplicationController < ActionController::API
         include DeviseTokenAuth::Concerns::SetUserByToken
-
-        private
-
-        def authenticate_user
-          unless logged_in?
-            flash[:error] = "このセクションにアクセスするにはログインが必要です"
-            redirect_to new_login_url # リクエストサイクルを停止する
-          end
-        end
 end

--- a/backend/app/controllers/prefectures_controller.rb
+++ b/backend/app/controllers/prefectures_controller.rb
@@ -1,6 +1,6 @@
 class PrefecturesController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
-
+  
   def create
     prefectures = Prefecture.new(create_params)
     return render json: { message: '成功しました', data: prefectures }, status: 200 if prefectures.save

--- a/backend/app/controllers/recruitments_controller.rb
+++ b/backend/app/controllers/recruitments_controller.rb
@@ -1,0 +1,42 @@
+class RecruitmentsController < ApplicationController
+  before_action :authenticate_user!, except: [:show, :index]
+  
+  def create
+    recruitments = Recruitment.new(create_params)
+    return render json: { message: '成功しました', data: recruitments }, status: 200 if recruitments.save
+
+    render json: { message: '保存出来ませんでした', errors: recruitments.errors.messages }, status: 400
+  end
+
+  def update
+    recruitment = Recruitment.find(params[:id])
+    return render json: { message: '成功しました', data: recruitment }, status: 200 if recruitment.update(create_params)
+
+    render json: { message: '保存出来ませんでした', errors: recruitment.errors }, status: 400
+  end
+
+  def index
+    recruitments = Recruitment.all
+    render json: { message: '成功しました', data: recruitments }, status: 200
+  end
+
+  def show
+    render json: { message: '成功しました', data: Recruitment.find(params[:id]) }, status: 200
+  end
+
+  def destroy
+    recruitment = Recruitment.find(params[:id])
+    return render json: { message: '削除に成功しました', data: recruitment }, status: 200 if recruitment.destroy
+    
+    render json: { message: '削除に失敗' }, status: 400
+  end
+
+  private
+
+  def create_params
+    params
+    .permit(:image, :name, :area, :sex, :number, :start_date, :end_date,
+     :purpose_body, :other_body, :sports_type_id, :prefecture_id, target_age_ids: [] )
+    .merge(user_id: current_user.id )
+  end
+end

--- a/backend/app/controllers/sports_types_controller.rb
+++ b/backend/app/controllers/sports_types_controller.rb
@@ -1,6 +1,6 @@
 class SportsTypesController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
-
+  
   def create
     sports_types = SportsType.new(create_params)
     return render json: { message: '成功しました', data: sports_types }, status: 200 if sports_types.save
@@ -32,6 +32,7 @@ class SportsTypesController < ApplicationController
   end
 
   private
+  
   def create_params
     params.permit(:name)
   end

--- a/backend/app/controllers/target_ages_controller.rb
+++ b/backend/app/controllers/target_ages_controller.rb
@@ -1,0 +1,39 @@
+class TargetAgesController < ApplicationController
+  before_action :authenticate_user!, except: [:show, :index]
+  
+  def create
+    target_ages = TargetAge.new(create_params)
+    return render json: { message: '成功しました', data: target_ages }, status: 200 if target_ages.save
+
+    render json: { message: '保存出来ませんでした', errors: target_ages.errors.messages }, status: 400
+  end
+
+  def update
+    target_age = TargetAge.find(params[:id])
+    return render json: { message: '成功しました', data: target_age }, status: 200 if target_age.update(create_params)
+
+    render json: { message: '保存出来ませんでした', errors: target_age.errors }, status: 400
+  end
+
+  def index
+    target_ages = TargetAge.all
+    render json: { message: '成功しました', data: target_ages }, status: 200
+  end
+
+  def show
+    render json: { message: '成功しました', data: TargetAge.find(params[:id]) }, status: 200
+  end
+
+  def destroy
+    target_age = TargetAge.find(params[:id])
+    return render json: { message: '削除に成功しました', data: target_age }, status: 200 if target_age.destroy
+    
+    render json: { message: '削除に失敗' }, status: 400
+  end
+
+  private
+
+  def create_params
+    params.permit(:name)
+  end
+end

--- a/backend/app/controllers/teams_controller.rb
+++ b/backend/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
-
+  
   def create
     teams = Team.new(create_params)
     return render json: { message: '成功しました', data: teams }, status: 200 if teams.save
@@ -35,7 +35,7 @@ class TeamsController < ApplicationController
 
   def create_params
     params
-    .permit(:name, :area, :sex, :track_record, :other_body, :sports_type_id, :prefecture_id )
+    .permit(:name, :area, :sex, :track_record, :other_body, :sports_type_id, :prefecture_id, target_age_ids: [] )
     .merge(user_id: current_user.id )
   end
 end

--- a/backend/app/models/recruitment.rb
+++ b/backend/app/models/recruitment.rb
@@ -11,7 +11,14 @@ class Recruitment < ApplicationRecord
   enum sex: { man: 0, woman: 1, mix: 2 }, _prefix: true
   validates :sex, presence: true
   validates :number, presence: true, numericality: { greater_than: 0 }
-  validates :start_date, presence: true
+  validate :date_before_start
   validates :end_date, comparison: { greater_than: :start_date }, presence: true
   validates :purpose_body, presence: true
+
+  require 'date'
+  
+  def date_before_start
+    return if start_date.blank?
+    errors.add(:start_date, "今日以降の日付を選択してください") if start_date < Date.today
+  end
 end

--- a/backend/app/models/recruitment.rb
+++ b/backend/app/models/recruitment.rb
@@ -1,16 +1,17 @@
 class Recruitment < ApplicationRecord
   belongs_to :sports_type
   belongs_to :user
-  belongs_to :area
+  belongs_to :prefecture
 
-  has_many :recruitment_target_ages
+  has_many :recruitment_target_ages, dependent: :destroy
+  has_many :target_ages,  through: :appointments
 
   validates :name, presence: true
   validates :area, presence: true
-  enum sex: { man: 0, woman: 1, mix: 2 }
-  validates :sex, presence: true, numericality: { only_integer: true }
+  enum sex: { man: 0, woman: 1, mix: 2 }, _prefix: true
+  validates :sex, presence: true
   validates :number, presence: true, numericality: { greater_than: 0 }
-  validates :start_date, date: true, presence: true
-  validates :end_date, date: true, presence: true
+  validates :start_date, presence: true
+  validates :end_date, comparison: { greater_than: :start_date }, presence: true
   validates :purpose_body, presence: true
 end

--- a/backend/app/models/target_age.rb
+++ b/backend/app/models/target_age.rb
@@ -1,6 +1,9 @@
 class TargetAge < ApplicationRecord
-  has_many :team_target_ages
-  has_many :recruitment_target_ages
+  has_many :recruitment_target_ages, dependent: :destroy
+  has_many :recruitments, through: :appointments
+
+  has_many :team_target_ages, dependent: :destroy
+  has_many :teams, through: :appointments
   
   validates :name, presence: true
 end

--- a/backend/app/models/team.rb
+++ b/backend/app/models/team.rb
@@ -3,7 +3,8 @@ class Team < ApplicationRecord
   belongs_to :sports_type
   belongs_to :prefecture
 
-  has_many :team_target_ages
+  has_many :team_target_ages, dependent: :destroy
+  has_many :target_ages,  through: :appointments
 
   validates :name, presence: true, length: { minimum: 2 }
   validates :area, presence: true, length: { minimum: 2 }

--- a/backend/db/migrate/20230831074948_add_references_to_recruitments.rb
+++ b/backend/db/migrate/20230831074948_add_references_to_recruitments.rb
@@ -1,0 +1,5 @@
+class AddReferencesToRecruitments < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :recruitments, :prefecture, null: false, foreign_key: true
+  end
+end

--- a/backend/db/migrate/20230831084240_change_column_to_null.rb
+++ b/backend/db/migrate/20230831084240_change_column_to_null.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToNull < ActiveRecord::Migration[7.0]
+  def up
+    change_column_null :recruitments, :prefecture_id, true
+  end
+
+  def down
+    change_column_null :recruitments, :prefecture_id, false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_21_050337) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_31_084240) do
   create_table "chat_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "chat_room_id"
@@ -65,6 +65,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_050337) do
     t.text "other_body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "prefecture_id"
+    t.index ["prefecture_id"], name: "index_recruitments_on_prefecture_id"
     t.index ["sports_type_id"], name: "index_recruitments_on_sports_type_id"
     t.index ["user_id"], name: "index_recruitments_on_user_id"
   end
@@ -124,4 +126,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_050337) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "recruitments", "prefectures"
 end

--- a/backend/test/controllers/recruitments_controller_test.rb
+++ b/backend/test/controllers/recruitments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecruitmentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/backend/test/controllers/target_ages_controller_test.rb
+++ b/backend/test/controllers/target_ages_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TargetAgesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mysql:8.0.34
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: "password"
+      MYSQL_ROOT_PASSWORD: password
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - mysql-data:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mysql:8.0.34
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: "password"
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - mysql-data:/var/lib/mysql


### PR DESCRIPTION
* recruitmentsテーブルに、prefecture_idのカラムを追加出来ていなかったので下のサイトを参考に追加しました。
https://qiita.com/krile136/items/0e824a6fb1d657bd3f97
しかし、これではnull: falseが追加されていたので、下のサイトでこれを削除しました。
https://qiita.com/new1/items/8a1bb6a04b77b005f264
最初から下のサイトを見れば良かったと感じています。
https://qiita.com/kurawo___D/items/e3694f7a870a1cc4738e

* 中間テーブルについて、model作成を下のサイトを参考にしました。
https://qiita.com/sazumy/items/1607627d475072701247

* recruitmentsテーブル作成時、end_dateについてはstart_dateと逆転しないように、ドキュメントの下の箇所を見ました。
[recruitments](https://railsguides.jp/active_record_validations.html#comparison)
start_dateについては、今日より前の日付けは実行出来ないように、下記のサイトを参考にしました。
https://qiita.com/thk__u/items/8c15b59f562c4974da37