### PR TITLE
Firebaseのpassword変更機能

### DIFF
--- a/frontend/src/views/SendEmailPage.vue
+++ b/frontend/src/views/SendEmailPage.vue
@@ -15,27 +15,24 @@
 </template>
 
 <script>
-import axios from 'axios';
+import { getAuth, sendPasswordResetEmail } from "firebase/auth"
 
 export default {
   data() {
     return {
-      password: "",
       email: "",
       error: null
     }
   },
   methods: {
-    async SetSendEmail() {
+    async redirectToSetSendEmail() {
       try {
         this.error = null
-        await axios.post('http://localhost:3001/auth/password#create', {
-          redirect_url: this.password,
-          email: this.email
-        })
-        this.$router.push({ name: 'PasswordPage' })
+        const auth = getAuth()
+        await sendPasswordResetEmail(auth, this.email)
+        alert('再設定のご案内メールを送信しました。')
       } catch (error) {
-      this.error = 'メールアドレスが違います'
+        this.error = 'メール送信に失敗しました。正しいメールアドレスを入力してください。'
       }
     }
   }


### PR DESCRIPTION
Firebaseのpassword変更機能を追加しました。
ミーティング時に話に出ましたように、google機能でuser登録している上でmail機能で登録しようとすると、エラーが発生しました。よって、google機能でuser登録している自分のレコードを削除し、mail機能で登録しました。
１、password変更機能の実行結果の画面が下です。メールアドレスにメールが送信されalertが表示しました。
![新規メモ](https://github.com/toshinori-m/stay_connect/assets/96866048/3ebf9b0e-e952-4cf1-8cb0-05de94a034b9)
２、メールが下のように来ました。（英語ですが）
![新規メモ1](https://github.com/toshinori-m/stay_connect/assets/96866048/ff73b967-47a4-4966-ba4c-9826dbaf8365)
３、表示するとその下のようになってい流ので、パスワードを入力して終了しました。
![新規メモ2](https://github.com/toshinori-m/stay_connect/assets/96866048/53c0e93e-9119-43b4-a916-5ded5f3d6b3e)
よろしくお願いします。

close https://github.com/toshinori-m/stay_connect/issues/50