### PR TITLE
新規登録画面の改善

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ActiveRecord::Base
   has_many :chat_room_users, dependent: :destroy
   has_many :chat_rooms,  through: :chat_room_users
 
-  validates :name, presence: true, length: { minimum: 2 }
+  validates :name, presence: true, length: { minimum: 2, maximum: 100 }
   enum sex: { man: 0, woman: 1 }
   validates :email, presence: true
   validates :email, uniqueness: true

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -16,5 +16,7 @@ module Myapp
     end
     config.action_controller.raise_on_open_redirects = false
     config.active_job.queue_adapter = :async
+    config.i18n.fallbacks = [:en]
+    config.i18n.default_locale = :ja
   end
 end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -1,0 +1,13 @@
+ja:
+  errors:
+    messages:
+      too_short: "が短すぎます。最小は%{count}文字です。"
+
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            name:
+              too_short: "が短すぎます。最小は%{count}文字です。"
+              too_long: "は%{count}文字以下で入力してください"

--- a/frontend/src/views/RegisterPage.vue
+++ b/frontend/src/views/RegisterPage.vue
@@ -1,22 +1,30 @@
 <template>
-  <div class="flex justify-center mt-20 md:mt-32">
+  <div class="flex justify-center mt-4 md:mt-12">
     <div class="md:w-2/5 w-full rounded-md bg-sky-100">
       <h2 class="text-center pt-10 font-bold text-3xl text-blue-600">新規ユーザー登録</h2>
       <div class="my-10">
         <div class="w-full md:md:flex md:px-8 items-center">
-          <p class="text-lg w-40 md:mx-2 pl-2 tracking-tighter text-sm">名前</p>
-          <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="text" required placeholder="名前（2文字以上）" v-model="name">
+          <p class="text-lg w-40 md:-ml-3 pl-2 tracking-tighter text-sm">名前</p>
+          <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="text" required placeholder="名前（2文字〜100文字）" v-model="name">
         </div>
         <div class="w-full md:md:flex md:px-8 items-center">
-          <p class="text-lg w-40 md:mx-2 pl-2 tracking-tighter text-sm">メールアドレス</p>
+          <p class="text-lg w-40 md:-ml-3 pl-2 tracking-tighter text-sm">メールアドレス</p>
           <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="email" required placeholder="メールアドレス" v-model="email">
         </div>
         <div class="w-full md:md:flex md:px-8 items-center">
-          <p class="text-lg w-40 md:mx-2 pl-2 tracking-tighter text-sm">パスワード</p>
+          <p class="text-lg w-40 md:-ml-3 pl-2 tracking-tighter text-sm">
+            <span class="md:inline-block inline tracking-tighter text-sm">パスワード</span>
+            <span class="md:hidden"> </span>
+            <span class="md:inline-block inline tracking-tighter text-sm">(2文字以上)</span>
+          </p>
           <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="password" required placeholder="パスワード（2文字以上）" v-model="password">
         </div>
         <div class="w-full md:md:flex md:px-8 items-center">
-          <p class="text-lg w-40 md:mx-2 pl-2 tracking-tighter text-sm">パスワード<br>（確認用）</p>
+          <p class="text-lg w-40 md:-ml-3 pl-2 tracking-tighter text-sm">
+            <span class="md:inline-block inline tracking-tighter text-sm">パスワード</span>
+            <span class="md:hidden"> </span>
+            <span class="md:inline-block inline tracking-tighter text-sm">（確認用）</span>
+          </p>
           <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="password" required placeholder="パスワード（確認用）" v-model="passwordConfirmation">
         </div>
       </div>

--- a/frontend/src/views/SignupPage.vue
+++ b/frontend/src/views/SignupPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center justify-center mt-20 md:mt-32">
+  <div class="flex items-center justify-center mt-4 md:mt-12">
     <div class="md:w-2/5 rounded-md bg-sky-100">
       <h2 class="text-center pt-10 font-bold text-3xl text-blue-600">ユーザー登録</h2>
       <div class="text-center my-5 text-blue-600">


### PR DESCRIPTION
新規登録画面の改善を行いました。
内容は下記です。
１、名前は100文字以上必要ない
２、[ "Name is too short (minimum is 2 characters)" ]を日本語にする。
３、パスワードが6文字以上必要と明記する。
４、ヘッダーと画面が離れすぎている。

上記改善を行っている途中で、下の問題が気がついたので、別にissuesを作成しました。
・新規登録時、メールアドレスのみOKだがname、passwordがエラー時dbにデータは登録されない。
しかし、FirebaseはOKとなり登録される。
よって、dbとFirebaseの登録が異なる。

close https://github.com/toshinori-m/stay_connect/issues/89