### PR TITLE
自己紹介画面の改善

### DIFF
--- a/frontend/src/views/BasicSetting/UserProfilePage.vue
+++ b/frontend/src/views/BasicSetting/UserProfilePage.vue
@@ -6,7 +6,7 @@
         <img :src="userProfile.image_url" alt="User Image" class="object-cover w-full h-full">
       </div>
       <div class="ml-4">
-        <button class="mt-2 mb-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300" @click="goToChatRoom(userProfile.id)" v-if="showChatButton(userProfile.id)">チーム代表とチャット開始</button>
+        <button class="mt-2 mb-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300" @click="goToChatRoom()" v-if="showChatButton()">チーム代表とチャット開始</button>
       </div>
     </div>
     <p class="mt-4 font-semibold text-blue-600">所属チーム紹介:</p>
@@ -44,8 +44,8 @@ export default {
     }
   },
   methods: {
-    showChatButton(profileId) {
-      return profileId !== this.currentUser.id;
+    showChatButton() {
+      return this.userProfile.id !== this.currentUser.id;
     },
     async fetchUserProfile() {
       try {
@@ -58,12 +58,12 @@ export default {
         this.errors.push('自己紹介を表示できませんでした。')
       }
     },
-    async goToChatRoom(otherUserId) {
+    async goToChatRoom() {
       try {
         this.errors = []
         const apiClient = getApiClient()
         const res = await apiClient.post('/chat_rooms', {
-          other_user_id: otherUserId
+          other_user_id: this.userProfile.id
         })
         this.$router.push({ name: 'ChatRoomPage', params: { id: res.data.data.id } })
       } catch {

--- a/frontend/src/views/BasicSetting/UserProfilePage.vue
+++ b/frontend/src/views/BasicSetting/UserProfilePage.vue
@@ -1,19 +1,18 @@
 <template>
-  <div class="mt-36 md:mt-14 max-w-2xl mx-auto p-6 bg-white shadow-lg rounded-lg">
+  <div class="mt-36 md:mt-14 max-w-2xl mx-auto p-6 bg-white shadow-lg rounded-lg break-words">
     <div class="error text-sm text-red-400" v-for="(errMsg, index) in errors" :key="index">{{ errMsg }}</div>
     <div class="flex items-center">
       <div class="w-32 h-32 rounded-full overflow-hidden">
         <img :src="userProfile.image_url" alt="User Image" class="object-cover w-full h-full">
       </div>
       <div class="ml-4">
-        <button class="mt-4 mb-1 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300" @click="goToChatRoom(userProfile.id)">チーム代表とチャット開始</button>
-        <p>（チャット送信5回まで無料）</p>
+        <button class="mt-2 mb-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300" @click="goToChatRoom(userProfile.id)" v-if="showChatButton(userProfile.id)">チーム代表とチャット開始</button>
       </div>
     </div>
     <p class="mt-4 font-semibold text-blue-600">所属チーム紹介:</p>
     <ul>
       <li v-for="team in teams" :key="team.id">
-        <button class="mt-2 mb-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300" @click="goToTeamIntroduction(team.id)">{{ team.name }}</button>
+        <button class="max-w-full text-left mt-2 mb-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700 transition duration-300 break-words" @click="goToTeamIntroduction(team.id)">{{ team.name }}</button>
       </li>
     </ul>
     <p class="text-sm text-red-400" v-if="!teams.length">チーム情報が存在しません。</p>
@@ -40,10 +39,14 @@ export default {
     return {
       userProfile: {},
       teams: [],
+      currentUser: {},
       errors: []
     }
   },
   methods: {
+    showChatButton(profileId) {
+      return profileId !== this.currentUser.id;
+    },
     async fetchUserProfile() {
       try {
         this.errors = []
@@ -91,7 +94,7 @@ export default {
         const apiClient = getApiClient()
         const res = await apiClient.get(`/users/${this.userProfile.id}/teams_profile`)
         this.teams = res.data
-      } catch (error) {
+      } catch {
         this.errors.push('チーム情報を取得できませんでした。')
       }
     },
@@ -101,10 +104,21 @@ export default {
       } catch {
         this.errors.push('チームIDが指定されていません。')
       }
-    }
+    },
+    async getCurrentUser() {
+      try {
+        this.errors = []
+        const apiClient = getApiClient();
+        const res = await apiClient.get('/users/show')
+        this.currentUser = res.data.data
+      } catch {
+        console.error('現在のユーザーを取得できませんでした')
+      }
+    },
   },
   mounted() {
     this.fetchUserProfile()
+    this.getCurrentUser()
   }
 }
 </script>


### PR DESCRIPTION
下記の内容について、自己紹介画面の改善を行いました。
１、自分の自己紹介画面から「チーム代表とチャット開始」ボタンを押すとチャットリストの一番上の人とのチャットが始まる。よって、自分の自己紹介画面を表示する場合は、ボタンを表示しないようにする。
２、「チャット送信5回まで無料」の表示を削除
３、所属チーム紹介、名前、自己紹介の文字を折り返して全て表示させる。

よろしくお願いします。

close https://github.com/toshinori-m/stay_connect/issues/98