### PR TITLE
チャットルーム一覧画面の改善（表示のみ）

### DIFF
--- a/frontend/src/views/ChatRoom/ChatRoomListPage.vue
+++ b/frontend/src/views/ChatRoom/ChatRoomListPage.vue
@@ -6,7 +6,8 @@
       <div class="my-14">
         <div class="error text-sm text-red-400">{{ error }}</div>
         <div class="flex flex-col items-center justify-center">
-          <div class="text-left my-3 sm:ml-4 sm:mr-6 w-72 pt-3 ring-offset-2 ring-2 rounded-lg" type="text" v-for="chat_room in chat_rooms" :key="chat_room.id">チャット名:{{ chat_room.other_user_name }}
+          <div class="text-left my-3 sm:ml-4 sm:mr-6 w-72 pt-3 ring-offset-2 ring-2 rounded-lg break-words" type="text" v-for="chat_room in chat_rooms" :key="chat_room.id">チャット名:
+            {{ chat_room.other_user_name }}
             <div class="flex justify-center">
               <button class="update_button" @click="editChatRoom(chat_room.id)">連絡</button>
             </div>


### PR DESCRIPTION
チャットルーム一覧画面の名前を折り返して全て表示する改善を行いました。

よろしくお願いします。

close https://github.com/toshinori-m/stay_connect/issues/99