### PR TITLE
チーム作成一覧画面の改善（表示のみ）

### DIFF
--- a/frontend/src/views/TeamProfile/TeamProfileListPage.vue
+++ b/frontend/src/views/TeamProfile/TeamProfileListPage.vue
@@ -13,7 +13,8 @@
       <div class="mt-10 mb-10">
         <div class="error text-sm text-red-400">{{ error }}</div>
         <div class="flex flex-col items-center mt-10 mb-10">
-          <div class="text-left my-3 sm:ml-4 sm:mr-6 w-72 pt-3 ring-offset-2 ring-2 rounded-lg" type="text" v-for="team in teams" :key="team.id">チーム名:{{ team.name }}
+          <div class="text-left my-3 sm:ml-4 sm:mr-6 w-72 pt-3 ring-offset-2 ring-2 rounded-lg break-words" type="text" v-for="team in teams" :key="team.id">チーム名:
+            {{ team.name }}
             <div class="flex justify-center">
               <button class="update_button" @click="editTeamProfile(team.id)">更新</button>
             </div>
@@ -38,8 +39,8 @@ export default {
   methods: {
     async getTeamProfile() {
       try {
-        const apiClient = getApiClient()
         this.error = null
+        const apiClient = getApiClient()
         const res = await apiClient.get('/teams')
         this.teams = res.data.data
       } catch {


### PR DESCRIPTION
チーム作成一覧画面の改善について、チーム名を折り返して全て表示させる改善を行いました。

よろしくお願いします。

close https://github.com/toshinori-m/stay_connect/issues/103