### PR TITLE
新規登録画面の改善（dbとFirebaseの登録が異なる）

### DIFF
--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -2,9 +2,6 @@ class UsersController < ApplicationController
   before_action :authenticate, except: [:create]
   
   def create
-    existing_user = User.find_by(email: user_params[:email])
-    render json: { errors: { email: ["既に登録されているメールアドレスです"] } }, status: :unprocessable_entity and return if existing_user
-    
     @user = User.new(user_params)
     @user.save!
   rescue ActiveRecord::RecordInvalid => e

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -3,10 +3,12 @@ class UsersController < ApplicationController
   
   def create
     existing_user = User.find_by(email: user_params[:email])
-    return head :ok if existing_user
+    render json: { errors: { email: ["既に登録されているメールアドレスです"] } }, status: :unprocessable_entity and return if existing_user
     
     @user = User.new(user_params)
-    render json: { error: @user.errors.full_messages }, status: :unprocessable_entity and return unless @user.save
+    @user.save!
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { errors: e.record.errors.messages }, status: :unprocessable_entity 
   end
 
   def update

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ActiveRecord::Base
 
   validates :name, presence: true, length: { minimum: 2, maximum: 100 }
   enum sex: { man: 0, woman: 1 }
-  validates :email, presence: true
+  validates :email, presence: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   validates :email, uniqueness: true
   enum email_notification: { receives: true, not_receive: false }
   validates :email_notification, presence: true

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ActiveRecord::Base
   has_many :chat_room_users, dependent: :destroy
   has_many :chat_rooms,  through: :chat_room_users
 
-  validates :name, presence: true, length: { minimum: 2, maximum: 100 }
+  validate :validate_name_length
   enum sex: { man: 0, woman: 1 }
   validates :email, presence: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   validates :email, uniqueness: true
@@ -35,6 +35,18 @@ class User < ActiveRecord::Base
         other_user_name: other_user&.name,
         other_user_id: other_user&.id
       }
+    end
+  end
+
+  private
+
+  def validate_name_length
+    if name.blank?
+      errors.add(:name, 'nameを入力してください。')
+    elsif name.length < 2
+      errors.add(:name, 'nameは最小は2文字必要です')
+    elsif name.length > 100
+      errors.add(:name, 'nameは最大100文字です')
     end
   end
 end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -10,9 +10,8 @@ ja:
       models:
         user:
           attributes:
-            name:
-              too_short: "nameが短すぎます。最小は%{count}文字です。"
-              too_long: "nameは%{count}文字以下で入力してください"
+            email:
+              taken: "このメールアドレスは既に存在します。"
             password:
               too_short: "passwordが短すぎます。最小は%{count}文字です。"
               too_long: "passwordは%{count}文字以下で入力してください"

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -11,8 +11,11 @@ ja:
         user:
           attributes:
             name:
-              too_short: "が短すぎます。最小は%{count}文字です。"
-              too_long: "は%{count}文字以下で入力してください"
+              too_short: "nameが短すぎます。最小は%{count}文字です。"
+              too_long: "nameは%{count}文字以下で入力してください"
+            password:
+              too_short: "passwordが短すぎます。最小は%{count}文字です。"
+              too_long: "passwordは%{count}文字以下で入力してください"
         recruitment:
           attributes:
             name:

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -174,11 +174,11 @@ const router = createRouter({
 })
 
 router.beforeEach((to, from, next) => {
-  let init = false
+  let firstAuthCheck = false
   onAuthStateChanged(auth, (user) => {
     const requiresAuth = to.matched.some(record => record.meta.requiresAuth)
-    if (init) return
-    init = true
+    if (firstAuthCheck) return
+    firstAuthCheck = true
     if (requiresAuth && !user) {
       next('/login')
     } else if (!requiresAuth && user) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -174,9 +174,11 @@ const router = createRouter({
 })
 
 router.beforeEach((to, from, next) => {
+  let init = false
   onAuthStateChanged(auth, (user) => {
     const requiresAuth = to.matched.some(record => record.meta.requiresAuth)
-
+    if (init) return
+    init = true
     if (requiresAuth && !user) {
       next('/login')
     } else if (!requiresAuth && user) {

--- a/frontend/src/views/RegisterPage.vue
+++ b/frontend/src/views/RegisterPage.vue
@@ -52,7 +52,6 @@ import { deleteUser } from "firebase/auth"
 export default {
   data () {
     return {
-      user: null,
       name: '',
       email: '',
       password: '',
@@ -70,7 +69,7 @@ export default {
   },
   methods: {
     async signUp() {
-      this.user = null
+      let user = null
       if (this.password !== this.passwordConfirmation) {
         this.error = "パスワードとパスワード確認が一致していません" 
         return
@@ -80,18 +79,18 @@ export default {
         this.errors = []
         const apiClient = getApiClient()
         const userCredential = await createUserWithEmailAndPassword(auth, this.email, this.password)
-        this.user = userCredential.user
+        user = userCredential.user
         const res = await apiClient.post('/users', {
           user: {
             name: this.name,
-            email: this.user.email,
-            uid: this.user.uid
+            email: user.email,
+            uid: user.uid
           }
         })
         this.$store.commit('setUser', {
           name: this.name,
-          email: this.user.email,
-          uid: this.user.uid
+          email: user.email,
+          uid: user.uid
         })
         this.$router.push({ name: 'HomePage' })
         return res
@@ -104,9 +103,9 @@ export default {
         const errorCode = error.code
         this.error = firebaseErrorCodes[errorCode] || "firebase登録中にエラーが発生しました。"
         this.errors = error.response?.data?.errors ? error.response.data.errors : ["データベース登録中にエラーが発生しました。"]
-        if (this.user) {
+        if (user) {
           try {
-            await deleteUser(this.user)
+            await deleteUser(user)
           } catch (deleteError) {
             this.errors = ["Firebaseユーザーの削除に失敗しました。"]
           }

--- a/frontend/src/views/RegisterPage.vue
+++ b/frontend/src/views/RegisterPage.vue
@@ -7,6 +7,9 @@
           <p class="text-lg w-40 md:-ml-3 pl-2 tracking-tighter text-sm">名前</p>
           <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="text" required placeholder="名前（2文字〜100文字）" v-model="name">
         </div>
+        <div v-if="remainingCharactersRegistertName <= 5" class="text-red-500">
+          名前はあと{{ remainingCharactersRegistertName }}文字までです。
+        </div>
         <div class="w-full md:md:flex md:px-8 items-center">
           <p class="text-lg w-40 md:-ml-3 pl-2 tracking-tighter text-sm">メールアドレス</p>
           <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="email" required placeholder="メールアドレス" v-model="email">
@@ -15,9 +18,9 @@
           <p class="text-lg w-40 md:-ml-3 pl-2 tracking-tighter text-sm">
             <span class="md:inline-block inline tracking-tighter text-sm">パスワード</span>
             <span class="md:hidden"> </span>
-            <span class="md:inline-block inline tracking-tighter text-sm">(2文字以上)</span>
+            <span class="md:inline-block inline tracking-tighter text-sm">( 6文字〜100文字 )</span>
           </p>
-          <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="password" required placeholder="パスワード（2文字以上）" v-model="password">
+          <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="password" required placeholder="パスワード（6文字〜100文字）" v-model="password">
         </div>
         <div class="w-full md:md:flex md:px-8 items-center">
           <p class="text-lg w-40 md:-ml-3 pl-2 tracking-tighter text-sm">
@@ -28,7 +31,8 @@
           <input class="w-full py-3 px-1.5 my-2 border-2 border-gray-200 box-border" type="password" required placeholder="パスワード（確認用）" v-model="passwordConfirmation">
         </div>
       </div>
-      <div class="error">{{ error }}</div>
+      <div class="error" v-for="(errMsg, index) in errors" :key="index">{{ errMsg }}</div>
+      <div class="error text-sm">{{ error }}</div>
       <form class= "my-5 text-center" @submit.prevent="signUp">
         <button class="ok_button">登録する</button>
       </form>
@@ -42,50 +46,70 @@
 <script>
 import getApiClient from '@/lib/apiClient'
 import { auth } from "@/plugins/firebase"
-import { createUserWithEmailAndPassword } from 'firebase/auth'
+import { createUserWithEmailAndPassword } from "firebase/auth"
+import { deleteUser } from "firebase/auth"
 
 export default {
   data () {
     return {
+      user: null,
       name: '',
       email: '',
       password: '',
       passwordConfirmation: '',
-      error: null
+      error: '',
+      errors: []
+    }
+  },
+  computed: {
+    remainingCharactersRegistertName() {
+      const maxChars = 100
+      const nameLength = this.name?.length
+      return maxChars - nameLength
     }
   },
   methods: {
     async signUp() {
+      this.user = null
       if (this.password !== this.passwordConfirmation) {
         this.error = "パスワードとパスワード確認が一致していません" 
         return
       }
       try {
+        this.error = ''
+        this.errors = []
         const apiClient = getApiClient()
-        this.error = null
         const userCredential = await createUserWithEmailAndPassword(auth, this.email, this.password)
-        const user = userCredential.user
+        this.user = userCredential.user
         const res = await apiClient.post('/users', {
           user: {
             name: this.name,
-            email: user.email,
-            uid: user.uid
+            email: this.user.email,
+            uid: this.user.uid
           }
         })
         this.$store.commit('setUser', {
           name: this.name,
-          email: user.email,
-          uid: user.uid
+          email: this.user.email,
+          uid: this.user.uid
         })
         this.$router.push({ name: 'HomePage' })
         return res
       } catch (error) {
-        if (error.response && error.response.data) {
-          this.error = error.response.data.error || error.response.data
-        } else if (error.code === 'auth/email-already-in-use') {
-          this.error = 'このメールアドレスは既に使用されています。'
-        } else {
-          this.error = '登録中にエラーが発生しました。'
+        const firebaseErrorCodes = {
+          'auth/invalid-email': 'メールアドレスの形式が不正です。',
+          'auth/weak-password': 'パスワードは6文字以上が必要です。',
+          'auth/email-already-in-use': 'このメールアドレスは既に使用されています。'
+        }
+        const errorCode = error.code
+        this.error = firebaseErrorCodes[errorCode] || "firebase登録中にエラーが発生しました。"
+        this.errors = error.response?.data?.errors ? error.response.data.errors : ["データベース登録中にエラーが発生しました。"]
+        if (this.user) {
+          try {
+            await deleteUser(this.user)
+          } catch (deleteError) {
+            this.errors = ["Firebaseユーザーの削除に失敗しました。"]
+          }
         }
       }
     },

--- a/frontend/src/views/RegisterPage.vue
+++ b/frontend/src/views/RegisterPage.vue
@@ -64,7 +64,7 @@ export default {
   computed: {
     remainingCharactersRegistertName() {
       const maxChars = 100
-      const nameLength = this.name?.length
+      const nameLength = this.name.length
       return maxChars - nameLength
     }
   },


### PR DESCRIPTION
新規登録画面の下の改善を行いました。
新規登録時、メールアドレスのみOKだがname、passwordがエラー時dbにデータは登録されない。
しかし、FirebaseはOKとなり登録されるので、dbとFirebaseの登録が異なる。
今回、userを管理するのはuidで行うため、passwordはdbには登録せずfirebaseのみの登録となっています。
よって、新規登録時dbへ登録するのは、name、email、uidとなるので、文字数の管理はnameのみとなります。
RegisterPage.vue内に下のコードが、オプショナルチェイニングを使用しています。他にコードを考えましたが分かりませんでした。
https://github.com/toshinori-m/stay_connect/blob/610399f518ed7af3631e0364f69053fe28047b0d/frontend/src/views/RegisterPage.vue#L106

「コンソールの注意表示を無くす」コミットとでは、nameの文字数により新規登録エラーとなった場合、下のメッセージが出ていたので、これを無くす改善です。
```
[Vue Router warn]: The "next" callback was called more than once in one navigation guard when going from "/" to "/register". It should be called exactly one time in each navigation guard. This will fail in production.
```

よろしくお願いします。

close https://github.com/toshinori-m/stay_connect/issues/106