### PR TITLE
READMEのセットアップ手順を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@
    ```bash
    git clone https://github.com/toshinori-m/stay_connect.git
    cd stay_connect
+   cd frontend
+   yarn install
+   cd ../
    ```
 2. **Dockerを使用してアプリケーションを起動**
 DockerおよびDocker Composeがインストールされていることを確認し、以下のコマンドを実行します。
@@ -54,7 +57,13 @@ DockerおよびDocker Composeがインストールされていることを確認
    docker-compose build   # イメージをビルド
    docker-compose up -d   # コンテナをバックグラウンドで起動
    ```
-3. **動作確認**
+3. **データベースのセットアップ**
+   ```bash
+   docker compose exec backend bash
+   bundle exec rails db:create
+   bundle exec rails db:migrate
+   ```
+4. **動作確認**
 下のURLにアクセスします
 - **Frontend（フロントエンド）**: [http://localhost:81/](http://localhost:81/)
 - **Backend（バックエンド）**: [http://localhost:3001/](http://localhost:3001/)
@@ -81,3 +90,9 @@ VUE_APP_AUTH_DOMAIN="YOUR_FIREBASE_AUTH_DOMAIN"
 # Firebase プロジェクトID
 VUE_APP_PROJECT_ID="YOUR_FIREBASE_PROJECT_ID"
 ```
+4. **FirebaseからAuthenticationの設定**
+   1. 「Authentication」を開く
+   - 左側メニューの「構築」セクション内の「Authentication」を選択
+   2. Googleサインインを有効化
+   - 「サインイン方法（Sign-in method）」タブを開く
+   - 「Google」をクリックし、設定画面で「有効にする」スイッチをオン

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['CORS_ORIGINS'] || 'http://localhost:81'
+    origins 'http://localhost:81'
 
     resource "*",
       headers: :any,


### PR DESCRIPTION
### 背景
初回起動時に以下のエラーが発生しました。
1. rack-cors の設定に誤りがあり、バックエンドが起動できませんでした。
2. フロントエンドで `vue-cli-service: not found` エラーが発生しました。

### 修正内容
1. README に以下を追加および修正しました。
   - Firebase の環境変数の設定方法を追加。
   - 初回起動時に必要なデータベースセットアップ手順 (`db:create`, `db:migrate`) を追加。
2. rack-cors の設定不足に関連するエラーを回避するための注意点を追加しました。

### 目的
- 初めてプロジェクトをクローンするユーザーが、セットアップ時にエラーを回避できるようにしました。
- 必要な手順を明確にすることで、環境構築をスムーズに進められるようにしました。

### 詳細
1. **README.md のセットアップ手順を修正**
   - `cd frontend` と `yarn install` を追加し、フロントエンドのセットアップ手順を明確化しました。
   - データベースのセットアップ手順 (`docker compose exec backend bash` → `bundle exec rails db:create` → `bundle exec rails db:migrate`) を追記しました。
   - Firebase Authentication の設定手順を追加しました（「Google サインインを有効化」など）。

2. **cors.rb を修正**
   - ローカル環境で使用できるように、CORSのオリジンを `http://localhost:81` に設定しました。

close https://github.com/toshinori-m/stay_connect/issues/136