### PR TITLE
データベースセットアップをentrypoint.shに移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,7 @@
    yarn install
    cd ../
    ```
-2. **データベースのセットアップ**
-   ```bash
-   docker compose exec backend bash
-   bundle exec rails db:create
-   bundle exec rails db:migrate
-   ```
-3. **Dockerを使用してアプリケーションを起動**
+2. **Dockerを使用してアプリケーションを起動**
 DockerおよびDocker Composeがインストールされていることを確認し、以下のコマンドを実行します。
    ```bash
    docker compose build   # Dockerイメージをビルド
@@ -63,7 +57,7 @@ DockerおよびDocker Composeがインストールされていることを確認
    docker-compose build   # イメージをビルド
    docker-compose up -d   # コンテナをバックグラウンドで起動
    ```
-4. **動作確認**
+3. **動作確認**
 下のURLにアクセスします
 - **Frontend（フロントエンド）**: [http://localhost:81/](http://localhost:81/)
 - **Backend（バックエンド）**: [http://localhost:3001/](http://localhost:3001/)

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -4,6 +4,13 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /myapp/tmp/pids/server.pid
 
+# Check if the database exists, and if not, create and migrate it
+if ! bundle exec rails db:exists; then
+  echo "Database does not exist. Creating and migrating now..."
+  bundle exec rails db:create
+  bundle exec rails db:migrate
+fi
+
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 
 exec "$@"


### PR DESCRIPTION
### 背景
READMEの手順に明記し、手動で実行するように記載していました。

この方法では、docker compose up のタイミングでデータベースが未作成のためにエラーが発生する問題がありました。

### 修正内容
1. **entrypoint.sh にデータベースセットアップ処理を追加：**
- rails db:create と rails db:migrate を自動的に実行する処理を追加しました。
- データベースが既に存在する場合は処理をスキップします。
2. **README.md の修正：**
- セットアップ手順の「データベースのセットアップ」に関する記載を削除しました。
- Dockerの起動手順に統合し、ユーザーが docker compose up を実行するだけで環境を構築できるようにしました。