### PR TITLE
seeds.rbに都道府県・競技名・種目・対象年齢の登録処理を追加し、entrypoint.shにseed投入処理を実装

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,7 +1,45 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# 都道府県名リスト
+prefecture_names = %w[
+  北海道 青森県 岩手県 宮城県 秋田県 山形県 福島県 茨城県 栃木県 群馬県 埼玉県 千葉県 東京都 神奈川県
+  新潟県 富山県 石川県 福井県 山梨県 長野県 岐阜県 静岡県 愛知県 三重県 滋賀県 京都府 大阪府 兵庫県 奈良県 和歌山県
+  鳥取県 島根県 岡山県 広島県 山口県 徳島県 香川県 愛媛県 高知県 福岡県 佐賀県 長崎県 熊本県 大分県 宮崎県 鹿児島県 沖縄県
+]
+
+# 都道府県の登録
+prefecture_names.each do |name|
+  Prefecture.create!(name: name)
+end
+
+# 競技名の登録
+sports_types = SportsType.create([
+  { name: '陸上短距離走' },
+  { name: '陸上中距離走' },
+  { name: '陸上長距離走' },
+  { name: 'バスケットボール' },
+  { name: '野球' }
+])
+
+# 種目名の登録
+sports_disciplines = [
+  # 陸上短距離走の種目
+  { name: '100m', sports_type_id: sports_types.find { |st| st.name == '陸上短距離走' }.id },
+  { name: '200m', sports_type_id: sports_types.find { |st| st.name == '陸上短距離走' }.id },
+  { name: '400m', sports_type_id: sports_types.find { |st| st.name == '陸上短距離走' }.id },
+
+  # 陸上中距離走の種目
+  { name: '800m', sports_type_id: sports_types.find { |st| st.name == '陸上中距離走' }.id },
+  { name: '1500m', sports_type_id: sports_types.find { |st| st.name == '陸上中距離走' }.id },
+  { name: '3000m', sports_type_id: sports_types.find { |st| st.name == '陸上中距離走' }.id },
+
+  # 陸上長距離走の種目
+  { name: '5000m', sports_type_id: sports_types.find { |st| st.name == '陸上長距離走' }.id },
+  { name: '10000m', sports_type_id: sports_types.find { |st| st.name == '陸上長距離走' }.id },
+
+  # 他の競技の種目
+  { name: '3x3バスケットボール', sports_type_id: sports_types.find { |st| st.name == 'バスケットボール' }.id }
+]
+
+SportsDiscipline.create!(sports_disciplines)
+
+# 対象年齢の登録
+TargetAge.create([{ name: '成人' }, { name: '大学生' }, { name: '高校生' }, { name: '中学生' }, { name: '小学生高学年' }, { name: '小学生低学年' }])

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -9,6 +9,7 @@ if ! bundle exec rails db:exists; then
   echo "Database does not exist. Creating and migrating now..."
   bundle exec rails db:create
   bundle exec rails db:migrate
+  bundle exec rails db:seed
 fi
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).


### PR DESCRIPTION
### 概要
1. **初期データの登録を追加**
- `seeds.rb`に都道府県、競技名、種目、対象年齢の初期データ登録処理を追加しました。
2. **エントリポイントスクリプトの拡張**
- `entrypoint.sh`に`rails db:seed`の実行を追加しました。
### 目的
- アプリケーション起動時に必要な初期データを簡単にセットアップできるようにしました。
- Docker環境でアプリケーションを起動する際、手動での`rails db:seed実行`を不要にしました。

close https://github.com/toshinori-m/stay_connect/issues/140