### PR TITLE
backendのENTRYPOINT周りを整理し、重複処理を削除

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,5 +18,3 @@ RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 3000
-
-CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     build:
       context: ./backend/
       dockerfile: Dockerfile
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
       - ./backend:/myapp
     environment:


### PR DESCRIPTION
## 概要
ENTRYPOINTスクリプトで初期処理を一元管理し、重複していた処理を削除しました。
## 変更内容
  1. **docker-compose.ymlを修正**
     - `command`から`rm -f tmp/pids/server.pid`を削除。
     - `command`を`bundle exec rails s -p 3000 -b '0.0.0.0'`に変更。
  2. **backendのDockerfileを修正**
     - `CMD ["rails", "server", "-b", "0.0.0.0"]`を削除。
## 詳細
- **ENTRYPOINTの役割**
  - `entrypoint.sh`はコンテナ起動時に必ず実行されるスクリプトなので、初期化処理（例: server.pidの削除）を担当します。
- **docker-compose.ymlのcommandの役割**
    - `command`はRailsサーバの起動のみを担当することで、可読性が向上します。
    - 起動時の処理が明確になり、ENTRYPOINTとの役割分担が整理します。