### PR TITLE
CORS設定を環境変数で管理するよう変更

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:81'
+    origins ENV['CORS_ORIGINS'] || 'http://localhost:81'
 
     resource "*",
       headers: :any,


### PR DESCRIPTION
### 概要
- 本番環境のAPIがフロントエンドからのリクエストを適切に許可できるよう、CORS設定を環境変数で管理できるようにしました。
- ローカル開発環境ではデフォルトで`http://localhost:81`を許可する設定としました。

### 変更内容
1. `config/initializers/cors.rb`を修正
   - 環境変数`CORS_ORIGINS`を使用して許可するよう指定しました。
   - 環境変数が未設定の場合、ローカル環境用のデフォルト値`http://localhost:81`を設定しました。
2. 本番環境の構成
   - フロントエンド：**Vercel**（フロントエンドアプリケーションのデプロイに使用）
   - バックエンド：**Render**（APIとバックエンドサービスのホスティングに使用）
   - 本番ドメイン：`https://www.stay-connect.click`

### 動作確認
- 本番環境で`CORS_ORIGINS=https://www.stay-connect.click`を設定し、フロントエンドからのリクエストが許可されることを確認しました。
- ローカル環境で、`http://localhost:81`からのリクエストが許可されることを確認しました。

### 今後の予定
- ご確認いただき、問題がなければ、PRをマージする前にVercelおよびRenderの設定を `master`ブランチへ変更します。