### PR TITLE
render-build.shの処理追加とseeds.rbのリファクタリング

### DIFF
--- a/backend/bin/render-build.sh
+++ b/backend/bin/render-build.sh
@@ -3,4 +3,5 @@ set -o errexit
 
 bundle exec rails db:create
 bundle exec rails db:migrate
+bundle exec rails db:seeds
 bundle exec rails s -p 3000 -b '0.0.0.0'

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,3 +1,5 @@
+errors = []
+
 # 都道府県名リスト
 prefecture_names = %w[
   北海道 青森県 岩手県 宮城県 秋田県 山形県 福島県 茨城県 栃木県 群馬県 埼玉県 千葉県 東京都 神奈川県
@@ -7,39 +9,61 @@ prefecture_names = %w[
 
 # 都道府県の登録
 prefecture_names.each do |name|
-  Prefecture.create!(name: name)
+  Prefecture.find_or_create_by!(name: name)
 end
 
 # 競技名の登録
-sports_types = SportsType.create([
+sports_types = [
   { name: '陸上短距離走' },
   { name: '陸上中距離走' },
   { name: '陸上長距離走' },
   { name: 'バスケットボール' },
+  { name: 'ハンドボール' },
   { name: '野球' }
-])
+]
+
+sports_types.each do |sports_type|
+  SportsType.find_or_create_by!(sports_type)
+end
 
 # 種目名の登録
 sports_disciplines = [
   # 陸上短距離走の種目
-  { name: '100m', sports_type_id: sports_types.find { |st| st.name == '陸上短距離走' }.id },
-  { name: '200m', sports_type_id: sports_types.find { |st| st.name == '陸上短距離走' }.id },
-  { name: '400m', sports_type_id: sports_types.find { |st| st.name == '陸上短距離走' }.id },
+  { name: '100m', sports_type_name: '陸上短距離走' },
+  { name: '200m', sports_type_name: '陸上短距離走' },
+  { name: '400m', sports_type_name: '陸上短距離走' },
 
   # 陸上中距離走の種目
-  { name: '800m', sports_type_id: sports_types.find { |st| st.name == '陸上中距離走' }.id },
-  { name: '1500m', sports_type_id: sports_types.find { |st| st.name == '陸上中距離走' }.id },
-  { name: '3000m', sports_type_id: sports_types.find { |st| st.name == '陸上中距離走' }.id },
+  { name: '800m', sports_type_name: '陸上中距離走' },
+  { name: '1500m', sports_type_name: '陸上中距離走' },
+  { name: '3000m', sports_type_name: '陸上中距離走' },
 
   # 陸上長距離走の種目
-  { name: '5000m', sports_type_id: sports_types.find { |st| st.name == '陸上長距離走' }.id },
-  { name: '10000m', sports_type_id: sports_types.find { |st| st.name == '陸上長距離走' }.id },
+  { name: '5000m', sports_type_name: '陸上長距離走' },
+  { name: '10000m', sports_type_name: '陸上長距離走' },
 
   # 他の競技の種目
-  { name: '3x3バスケットボール', sports_type_id: sports_types.find { |st| st.name == 'バスケットボール' }.id }
+  { name: '3x3バスケットボール', sports_type_name: 'バスケットボール' }
 ]
 
-SportsDiscipline.create!(sports_disciplines)
+sports_disciplines.each do |discipline|
+  begin
+    sports_type = SportsType.find_by!(name: discipline[:sports_type_name])
+
+    SportsDiscipline.find_or_create_by!(name: discipline[:name], sports_type_id: sports_type.id)
+  rescue ActiveRecord::RecordNotFound => e
+    errors << { type: 'RecordNotFound', message: e.message, related_data: discipline }
+  rescue ActiveRecord::RecordInvalid => e
+    errors << { type: 'RecordInvalid', message: e.record.errors.full_messages, related_data: discipline }
+  end
+end
 
 # 対象年齢の登録
-TargetAge.create([{ name: '成人' }, { name: '大学生' }, { name: '高校生' }, { name: '中学生' }, { name: '小学生高学年' }, { name: '小学生低学年' }])
+target_ages = %w[成人 大学生 高校生 中学生 小学生高学年 小学生低学年]
+target_ages.each do |age|
+  TargetAge.find_or_create_by!(name: age)
+end
+
+errors.each do |error|
+  puts "Error Type: #{error[:type]}, Message: #{error[:message]}, Data: #{error[:related_data]}"
+end


### PR DESCRIPTION
### 概要
`render-build.sh`と`seeds.rb`を修正し、アプリケーションの初期化処理を改善しました。
### 背景
- アプリケーション初期化時に、データの重複登録やエラーが発生していたため、これらを防止し、処理の信頼性を向上しました。
- backendのseeds.rbのデータをrails db:seed を利用して登録するよう変更しました。
### 変更内容
**render-build.sh**
- db:seed 実行処理を追加し、データベースの初期化を自動化しました。
**seeds.rb**
- `find_or_create_by!`を使用して重複登録を防止しました。
- 種目登録時のエラーハンドリングを追加しました。
### テスト
- ローカル環境の`Docker`コンテナ内で以下を確認しました。
  1. `rails db:create`が成功
  2. `rails db:migrate`がエラーなく実行
  3. `rails db:seed`で重複登録が発生することなくデータを登録

close https://github.com/toshinori-m/stay_connect/issues/147