### PR TITLE
Render デプロイ失敗の原因を解消する修正

### DIFF
--- a/backend/bin/render-build.sh
+++ b/backend/bin/render-build.sh
@@ -3,5 +3,5 @@ set -o errexit
 
 bundle exec rails db:create
 bundle exec rails db:migrate
-bundle exec rails db:seeds
+bundle exec rails db:seed
 bundle exec rails s -p 3000 -b '0.0.0.0'


### PR DESCRIPTION
### 概要
Render デプロイが失敗した原因となっていた`render-build.sh`内の誤記を修正しました。

### 背景
- `render-build.sh`にて`db:seeds`を実行しようとしていましたが、このタスクは存在せずデプロイが失敗しました。
- 正しいタスク名は`db:seed`であるため、修正しました。

### 修正内容
- `render-build.sh`内の`bundle exec rails db:seeds`を`bundle exec rails db:seed`に修正しました。