### PR TITLE
WebSocketとAPIの接続URLを環境変数で適切に設定

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -16,7 +16,7 @@ gem "puma", "~> 5.0"
 gem "jbuilder", '~> 2.10'
 
 # Use Redis adapter to run Action Cable in production
-# gem "redis", "~> 4.0"
+gem "redis", "~> 4.0"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.19.0)
     msgpack (1.7.2)
-    mysql2 (0.5.5)
     net-imap (0.3.7)
       date
       net-protocol
@@ -176,6 +175,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    redis (4.8.1)
     reline (0.3.7)
       io-console (~> 0.5)
     responders (3.1.0)
@@ -203,12 +203,12 @@ DEPENDENCIES
   devise_token_auth (~> 1.2, >= 1.2.2)
   dotenv-rails
   jbuilder (~> 2.10)
-  mysql2 (~> 0.5)
   pg
   pry-byebug
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.7)
+  redis (~> 4.0)
   tzinfo-data
 
 RUBY VERSION

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -18,6 +18,6 @@ module Myapp
     config.active_job.queue_adapter = :async
     config.i18n.fallbacks = [:en]
     config.i18n.default_locale = :ja
-    config.hosts << "stay-connect.onrender.com"
+    config.hosts << ENV['ALLOWED_HOSTS']
   end
 end

--- a/backend/config/cable.yml
+++ b/backend/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV['REDIS_URL']%>
   channel_prefix: myapp_production

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -35,8 +35,13 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+  config.action_cable.url = "wss://stay-connect.onrender.com/cable"
+  config.action_cable.allowed_request_origins = [
+  'https://www.stay-connect.click', # カスタムドメイン
+  'https://stay-connect-p5yxvbsqw-toshinori-ms-projects.vercel.app', # デフォルトドメイン
+  %r{\Ahttps://stay-connect-git-.*\.vercel\.app\z}, # プレビューデプロイの動的なオリジン許可
+  'https://stay-connect.onrender.com' # RenderのバックエンドURL
+]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -88,4 +88,16 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = { host: 'www.stay-connect.click' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'gmail.com',
+    user_name: ENV['EMAIL_ADDRESS'],
+    password: ENV['EMAIL_PASSWORD'],
+    authentication: 'plain',
+    enable_starttls_auto: true
+  }
 end

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -37,9 +37,8 @@ Rails.application.configure do
   # config.action_cable.mount_path = nil
   config.action_cable.url = ENV['BACKEND_CABLE_URL']
   config.action_cable.allowed_request_origins = [
-    ENV['CORS_ORIGINS'],
-    ENV['FRONTEND_URL'],
-    ENV['BACKEND_URL'],
+    ENV['BRANCH_ORIGIN'],
+    ENV['FRONTEND_ORIGIN']
   ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
@@ -88,7 +87,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = ENV['MAILER_HOST']
+  config.action_mailer.default_url_options = ENV['FRONTEND_ORIGIN']
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: 'smtp.gmail.com',

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -35,13 +35,12 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  config.action_cable.url = "wss://stay-connect.onrender.com/cable"
+  config.action_cable.url = ENV['BACKEND_CABLE_URL']
   config.action_cable.allowed_request_origins = [
-  'https://www.stay-connect.click', # カスタムドメイン
-  'https://stay-connect-p5yxvbsqw-toshinori-ms-projects.vercel.app', # デフォルトドメイン
-  %r{\Ahttps://stay-connect-git-.*\.vercel\.app\z}, # プレビューデプロイの動的なオリジン許可
-  'https://stay-connect.onrender.com' # RenderのバックエンドURL
-]
+    ENV['CORS_ORIGINS'],
+    ENV['FRONTEND_URL'],
+    ENV['BACKEND_URL'],
+  ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
@@ -89,7 +88,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'www.stay-connect.click' }
+  config.action_mailer.default_url_options = ENV['MAILER_HOST']
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: 'smtp.gmail.com',

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['BRANCH_ORIGIN'].presence || ENV['FRONTEND_ORIGIN'].presence || 'http://localhost:81'
+    origins ENV['BRANCH_ORIGIN'] || ENV['FRONTEND_ORIGIN'] || 'http://localhost:81'
 
     resource "*",
       headers: :any,

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['CORS_ORIGINS'] || 'http://localhost:81'
+    origins ENV['BRANCH_ORIGIN'].presence || ENV['FRONTEND_ORIGIN'].presence || 'http://localhost:81'
 
     resource "*",
       headers: :any,

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -31,5 +31,6 @@ Rails.application.routes.draw do
         resources :chat_room_users, only: [:index, :create]
       end
     end
+    root to: proc { [204, {}, ['']] }
   end
 end

--- a/frontend/src/views/ChatRoom/ChatRoomPage.vue
+++ b/frontend/src/views/ChatRoom/ChatRoomPage.vue
@@ -95,7 +95,9 @@ export default {
   },
   mounted() {
     this.fetchChatRoomData()
-    const consumer = createConsumer(`ws://localhost:3001/cable?uid=${this.$store.getters['uid']}`)
+    const apiBaseUrl = process.env.VUE_APP_API_BASE_URL || 'http://localhost:3001'
+    const wsProtocol = apiBaseUrl.startsWith('https') ? 'wss' : 'ws'
+    const consumer = createConsumer(`${wsProtocol}://${new URL(apiBaseUrl).host}/cable?uid=${this.$store.getters['uid']}`)
     this.messageChannel = consumer.subscriptions.create({ channel: "RoomChannel", room_id: this.$route.params.id }, {
       connected: () => {
         this.getChatMessage()

--- a/frontend/src/views/PasswordPage.vue
+++ b/frontend/src/views/PasswordPage.vue
@@ -32,7 +32,8 @@ export default {
     async SetPassword() {
       try {
         this.error = null
-        const res = await axios.post('http://localhost:3001/application', {
+        const apiBaseUrl = process.env.VUE_APP_API_BASE_URL || 'http://localhost:3001'
+        const res = await axios.post(`${apiBaseUrl}/application`, {
           password: this.password,
           password_confirmation: this.password_confirmation
         })


### PR DESCRIPTION
### 概要
- 本番環境で`Action Cable`が`Redis`を利用する設定を追加することで、WebSocket通信が正常に動作するよう修正しました。
- `Password`を忘れた時のページが、本番環境で正しく動作しない問題を修正しました。
- 本番環境で`No route matches [GET] "/"`のエラーが発生しないよう、`root`を`204 No Content`で処理する設定を追加しました。
- 本番環境でメール送信 (`ActionMailer`) の設定を追加しました。

### 変更内容
- `Gemfile`に`redis`を追加しました。
- `config/cable.yml`のproduction設定で`Redis`を使用するよう修正しました。
- Render環境で以下の設定をしました。
  - Redis データベースを作成し、接続情報（`REDIS_URL`）を取得しました。
  - 環境変数`REDIS_URL`を`backend_stay_connect`に追加しました。
  - 環境変数`RAILS_LOG_TO_STDOUT=true`を追加（ログが標準出力に出力されるよう設定）しました。
- `config/routes.rb`に`root`を追加し、本番環境で`No route matches [GET] "/"`のエラーが発生しないように修正しました。
  - `root to: proc { [204, {}, ['']] }` を設定し、不要なリクエストを `204 No Content` で処理するようにしました。
- 本番環境 (`production.rb`) に`ActionMailer`の設定を追加しました。
  - `config.action_mailer.default_url_options = { host: 'www.stay-connect.click' }` を設定し、メール内のリンクが正しい URL で生成されるようにしました。
  - `config.action_mailer.smtp_settings`を設定し、GmailのSMTPサーバーを使用できるようにしました。
  
### 動作確認内容
- **ローカル環境**
  - `adapter: async`を使用して問題なく動作することを確認しました。
  - ターミナルで`rails routes | grep root`を実行し、`root GET /`が設定していることを確認しました。
- **本番環境**
  - `adapter: redis`を使用して問題なくWebSocket通信が動作することを確認しました。
  - Render の「Logs」で Redis に関連するエラーが表示されていないことを確認しました。
  - `No route matches [GET] "/"`のエラーが発生しなくなったことを確認しました。
  - `ActionMailer`を使用し、メールが正しく送信されることを確認しました。

close https://github.com/toshinori-m/stay_connect/issues/151