### PR TITLE
SignupPageのUIを作成し、ページ遷移を実装

### DIFF
--- a/frontend-react/src/pages/SignupPage.tsx
+++ b/frontend-react/src/pages/SignupPage.tsx
@@ -1,68 +1,49 @@
-import { useState } from "react"
-import { useNavigate } from "react-router-dom"
-import { isApiError } from "@/types"
+import { ButtonProps } from "@/types"
 
 const RegisterPage = () => {
-  const [error, setError] = useState<string | null>(null)
-  const navigate = useNavigate()
-
-  const redirectToRegister = () => {
-    navigate("/register")
+  const handleRegisterClick = () => {
+    console.log("次のissueで作成予定！")
   }
 
-  const redirectToLogin = () => {
-    navigate("/login")
+  const handleLoginClick = () => {
+    console.log("次のissueで作成予定！")
   }
 
-  const signInWithGoogle = async () => {
-    try {
-      setError(null)
-      navigate("/")
-    } catch (error: unknown) {
-      if (isApiError(error)) {
-        setError(error.response?.data?.error || "エラーが発生しました")
-      }
-    }
+  const handleGoogleSignIn = () => {
+    console.log("次のissueで作成予定！")
   }
 
   return (
     <div className="flex items-center justify-center mt-40 md:mt-32">
-      <div className="md:w-2/5 rounded-md bg-sky-100">
+      <div className="w-80 md:w-2/5 rounded-md bg-sky-100">
         <h2 className="text-center pt-10 font-bold text-3xl text-blue-600">
           ユーザー登録
         </h2>
         <div className="text-center my-5 text-blue-600">
-          <form onSubmit={(e) => { e.preventDefault(); redirectToRegister() }}>
-            <button
-              type="submit"
-              className="md:w-3/4 w-64 my-10 text-blue-600 border-4 border-blue-300 border-double px-3 py-2"
-            >
-              <span className="i-lucide-mail w-5 h-5 float-left"></span>
-              <i className="px-3">メールアドレスで登録</i>
-            </button>
-          </form>
-
-          <button
-            onClick={signInWithGoogle}
-            className="md:w-3/4 w-64 my-2 text-blue-600 border-4 border-blue-300 border-double px-3 py-2"
-          >
-            <span className="i-tabler-brand-google w-5 h-5 float-left"></span>
-            <i className="px-3">Googleアカウントで登録</i>
-          </button>
-
-          <form onSubmit={(e) => { e.preventDefault(); redirectToLogin() }}>
-            <button
-              type="submit"
-              className="md:w-3/4 w-70 my-10 text-blue-600 bg-clip-padding p-1 border-4 border-violet-300 border-dashed"
-            >
-              アカウントをお持ちの方はこちら
-            </button>
-          </form>
-
-          {error && <div className="error text-red-500">{error}</div>}
+          <Button onClick={handleRegisterClick} icon="i-lucide-mail">
+            メールアドレスで登録
+          </Button>
+          <Button onClick={handleGoogleSignIn} icon="i-tabler-brand-google">
+            Googleアカウントで登録
+          </Button>
+          <Button onClick={handleLoginClick} className="border-violet-300 border-dashed px-0">
+            アカウントをお持ちの方はこちら
+          </Button>
         </div>
       </div>
     </div>
+  )
+}
+
+const Button = ({ onClick, children, icon, className = "" }: ButtonProps) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`md:w-3/4 w-80 my-3 text-blue-600 border-4 border-blue-300 border-double px-3 py-2 ${className}`}
+    >
+      {icon && <span className={`${icon} w-5 h-5 float-left`}></span>}
+      <span className="px-3">{children}</span>
+    </button>
   )
 }
 

--- a/frontend-react/src/pages/SignupPage.tsx
+++ b/frontend-react/src/pages/SignupPage.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { isApiError } from "@/types"
+
+const RegisterPage = () => {
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const redirectToRegister = () => {
+    navigate("/register")
+  }
+
+  const redirectToLogin = () => {
+    navigate("/login")
+  }
+
+  const signInWithGoogle = async () => {
+    try {
+      setError(null)
+      navigate("/")
+    } catch (error: unknown) {
+      if (isApiError(error)) {
+        setError(error.response?.data?.error || "エラーが発生しました")
+      }
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center mt-40 md:mt-32">
+      <div className="md:w-2/5 rounded-md bg-sky-100">
+        <h2 className="text-center pt-10 font-bold text-3xl text-blue-600">
+          ユーザー登録
+        </h2>
+        <div className="text-center my-5 text-blue-600">
+          <form onSubmit={(e) => { e.preventDefault(); redirectToRegister() }}>
+            <button
+              type="submit"
+              className="md:w-3/4 w-64 my-10 text-blue-600 border-4 border-blue-300 border-double px-3 py-2"
+            >
+              <span className="i-lucide-mail w-5 h-5 float-left"></span>
+              <i className="px-3">メールアドレスで登録</i>
+            </button>
+          </form>
+
+          <button
+            onClick={signInWithGoogle}
+            className="md:w-3/4 w-64 my-2 text-blue-600 border-4 border-blue-300 border-double px-3 py-2"
+          >
+            <span className="i-tabler-brand-google w-5 h-5 float-left"></span>
+            <i className="px-3">Googleアカウントで登録</i>
+          </button>
+
+          <form onSubmit={(e) => { e.preventDefault(); redirectToLogin() }}>
+            <button
+              type="submit"
+              className="md:w-3/4 w-70 my-10 text-blue-600 bg-clip-padding p-1 border-4 border-violet-300 border-dashed"
+            >
+              アカウントをお持ちの方はこちら
+            </button>
+          </form>
+
+          {error && <div className="error text-red-500">{error}</div>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RegisterPage

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -1,10 +1,12 @@
 import { Routes, Route } from "react-router-dom"
 import OpenPage from "@/pages/OpenPage"
+import SignupPage from "@/pages/SignupPage"
 
 export default function AppRouter() {
   return (
     <Routes>
       <Route path="/" element={<OpenPage />} />
+      <Route path="/signup" element={<SignupPage />} />
     </Routes>
   )
 }

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -1,0 +1,18 @@
+// API のエラー型
+export interface ApiError {
+  response?: {
+    data?: {
+      error?: string;
+    }
+  }
+}
+
+// 型ガード関数
+export function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "response" in error &&
+    typeof (error as ApiError).response?.data?.error === "string"
+  )
+}

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -1,18 +1,6 @@
-// API のエラー型
-export interface ApiError {
-  response?: {
-    data?: {
-      error?: string;
-    }
-  }
-}
-
-// 型ガード関数
-export function isApiError(error: unknown): error is ApiError {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "response" in error &&
-    typeof (error as ApiError).response?.data?.error === "string"
-  )
+export type ButtonProps = {
+  onClick?: () => void
+  children: React.ReactNode
+  icon?: string
+  className?: string
 }


### PR DESCRIPTION
## SignupPage新規作成

### 変更内容
- SignupPage（新規登録ページ）を作成
- 「Googleアカウントで登録」ボタンを追加し、URL `/` （仮としてOpen画面）へ遷移するよう実装
- 「メールアドレスで登録」ボタンを追加し、URL `/register`（新規ユーザー登録画面） へ遷移するよう実装
- 「アカウントをお持ちの方はこちら」ボタンを追加し、URL `/login`（ログイン画面） へ遷移するよう実装
- ページ本体（`/register`, `/login`）、google認証は未作成 → 次の`Issue`で対応予定

### 動作確認方法
1. `http://localhost:5173/signup` にアクセス
2. 各ボタンをクリックし、指定の URL に遷移することを確認
   - 「Googleアカウントで登録」 → `/`（仮としてOpen画面）
   - 「メールアドレスで登録」 → `/register`
   - 「アカウントをお持ちの方はこちら」 → `/login`
3. 遷移先のページは未作成のため、画面は真っ白（次の Issue で作成予定）

close https://github.com/toshinori-m/stay_connect/issues/160