### PR TITLE
googleアカウント登録時、Railsのエラーレスポンスを適切に処理するよう修正

### DIFF
--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -3,6 +3,9 @@ class UsersController < ApplicationController
   
   def create
     @user = User.new(user_params)
+
+    render json: { error_type: "duplicate" }, status: :unprocessable_entity and return if User.exists?(uid: @user.uid)
+
     @user.save!
   rescue ActiveRecord::RecordInvalid => e
     render json: { errors: e.record.errors.messages }, status: :unprocessable_entity 

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -3,9 +3,6 @@ class UsersController < ApplicationController
   
   def create
     @user = User.new(user_params)
-
-    render json: { error_type: "duplicate" }, status: :unprocessable_entity and return if User.exists?(uid: @user.uid)
-
     @user.save!
   rescue ActiveRecord::RecordInvalid => e
     render json: { errors: e.record.errors.messages }, status: :unprocessable_entity 

--- a/frontend-react/src/pages/SignupPage.tsx
+++ b/frontend-react/src/pages/SignupPage.tsx
@@ -1,7 +1,7 @@
 import { ButtonProps, RailsApiError } from "@/types"
 import { useState } from "react"
 import { auth } from "@/lib/firebase"
-import { GoogleAuthProvider, signInWithPopup } from "firebase/auth"
+import { GoogleAuthProvider, signInWithPopup, User } from "firebase/auth"
 import { useApiClient } from "@/hooks/useApiClient"
 import { useSetAuth } from "@/context/useAuthContext"
 import { FirebaseError } from "firebase/app"
@@ -46,7 +46,7 @@ const RegisterPage = () => {
   }
 
   const handleGoogleSignIn = async () => {
-    let firebaseUser
+    let firebaseUser: User | null = null
 
     try {
       setError(null)
@@ -68,7 +68,6 @@ const RegisterPage = () => {
     } catch (error: unknown) {
       if (error instanceof FirebaseError) {
         setError(getErrorMessage(error))
-        setUser(null)
         return
       }  
 
@@ -77,7 +76,7 @@ const RegisterPage = () => {
         const errorData = responseError.response?.data
 
         if (errorData?.errors?.email?.includes("このメールアドレスは既に存在します。")) {
-          setUser(firebaseUser ?? null)
+          setUser(firebaseUser)
           // TODO: 後続タスクでhome画面を追加する際修正
           console.log("home画面は次のissueで作成予定！")
           return
@@ -89,8 +88,6 @@ const RegisterPage = () => {
               console.error("Firebase ユーザーの削除に失敗しました:", deleteError)
             })
           }
-
-          setUser(null)
           return
         }
       } else {
@@ -101,7 +98,7 @@ const RegisterPage = () => {
   }
 
   return (
-    <div className="flex items-center justify-center mt-40 md:mt-32">
+    <div className="flex items-center justify-center mt-16 md:mt-20">
       <div className="w-80 md:w-2/5 rounded-md bg-sky-100">
         <h2 className="text-center pt-10 font-bold text-3xl text-blue-600">
           ユーザー登録

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -13,6 +13,7 @@ export interface RailsApiError {
     status?: number
     data?: {
       error?: string
+      errors?: { [key: string]: string[] }
     }
   }
 }


### PR DESCRIPTION
### 変更内容
- Railsのエラー種別（error_type）を判別して適切なメッセージを表示するよう修正
- Googleサインイン後のエラーハンドリングを修正
  - error_type === "duplicate" → 「このメールアドレスは既に登録されています。ログイン画面からGoogleアカウントでログインして下さい。」
  - その他のエラー → 「googleアカウントで登録できませんでした。再度登録してください。」
### 動作確認方法
1. `http://localhost:5173/signup` にアクセス
2. Rails 側でユーザー登録を失敗させる
- users_controller.rb を下のように変更し、DB への登録を失敗させると下を確認
  - 「googleアカウントで登録できませんでした。再度登録してください。」と表示
  - firebaseにユーザー登録させていない
```
  def create
    @user = User.new(user_params)

    render json: { error_type: "duplicate" }, status: :unprocessable_entity and return if User.exists?(uid: @user.uid)
    raise ActiveRecord::RecordInvalid.new(@user)
  rescue ActiveRecord::RecordInvalid => e
    render json: { errors: e.record.errors.messages }, status: :unprocessable_entity 
  end
```
3. `Googleアカウントで登録`ボタンをクリックし、下を確認
   - Firebase にメールアドレスと UID が登録
   - Docker の PostgreSQL に UID、name、email が保存
4. 再度 Googleアカウントで登録 を試す
   - 既存ユーザーの場合、エラーメッセージが適切に表示されることを確認 → 「このメールアドレスは既に登録されています。ログイン画面からGoogleアカウントでログインして下さい。」

close https://github.com/toshinori-m/stay_connect/issues/168