### PR TITLE
エラー管理を配列に統一

### DIFF
--- a/frontend-react/src/pages/LoginPage.tsx
+++ b/frontend-react/src/pages/LoginPage.tsx
@@ -9,9 +9,10 @@ import { FirebaseError } from "firebase/app"
 import getFirebaseErrorMessage from "@/lib/getFirebaseErrorMessage"
 import { useApiClient } from "@/hooks/useApiClient"
 import { AxiosError } from "axios"
+import apiErrorHandler from "@/utils/apiErrorHandler"
 
 export default function LoginPage() {
-  const [error, setError] = useState<string | null>(null)
+  const [errors, setErrors] = useState<string[]>([])
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const navigate = useNavigate()
@@ -28,19 +29,20 @@ export default function LoginPage() {
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
+    const newErrors: string[] = []
 
     if (!email.trim()) {
-      setError("メールアドレスを入力してください。")
+      newErrors.push("メールアドレスを入力してください。")
       return
     }
 
     if (!password) {
-      setError("パスワードを入力してください。")
+      newErrors.push("パスワードを入力してください。")
       return
     }
 
     try {
-      setError(null)
+      setErrors([])
       const userCredential = await signInWithEmailAndPassword(auth, email, password)
       const user = userCredential.user
       try {
@@ -56,14 +58,16 @@ export default function LoginPage() {
             },
           })
         } else {
-          setError("予期しないエラーが発生しました。")
+          apiErrorHandler(error, setErrors)
         }
       }
 
       setUser(user)
       navigate("/home")
     } catch (error: unknown) {
-      setError(error instanceof FirebaseError ? getFirebaseErrorMessage(error) : "予期しないエラーが発生しました。")
+      setErrors([
+        error instanceof FirebaseError ? getFirebaseErrorMessage(error) : "予期しないエラーが発生しました。",
+      ])
       setUser(null)
     }
   }
@@ -71,14 +75,16 @@ export default function LoginPage() {
   const signInWithGoogle = async () => {
 
     try {
-      setError(null)
+      setErrors([])
       const provider = new GoogleAuthProvider()
       const result = await signInWithPopup(auth, provider)
       const firebaseUser = result.user
       setUser(firebaseUser)
       navigate("/home")
     } catch (error: unknown) {
-      setError(error instanceof FirebaseError ? getFirebaseErrorMessage(error) : "予期しないエラーが発生しました。")
+      setErrors([
+        error instanceof FirebaseError ? getFirebaseErrorMessage(error) : "予期しないエラーが発生しました。",
+      ])
       setUser(null)
     }
   }
@@ -103,7 +109,13 @@ export default function LoginPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
-            {error && <div className="text-sm text-red-500 my-4">{error}</div>}
+            {errors.length > 0 && (
+              <div className="text-sm text-red-500 my-4">
+                {errors.map((error, index) => (
+                  <div key={index}>{error}</div>
+                ))}
+              </div>
+            )}
             <button className="btn-ok my-4 md:mb-0 md:mr-4">ログイン</button>
           </form>
           <div className="flex flex-col items-center my-7 text-blue-600">

--- a/frontend-react/src/pages/LoginPage.tsx
+++ b/frontend-react/src/pages/LoginPage.tsx
@@ -33,11 +33,14 @@ export default function LoginPage() {
 
     if (!email.trim()) {
       newErrors.push("メールアドレスを入力してください。")
-      return
     }
-
+    
     if (!password) {
       newErrors.push("パスワードを入力してください。")
+    }
+    
+    if (newErrors.length > 0) {
+      setErrors(newErrors)
       return
     }
 

--- a/frontend-react/src/pages/RegisterPage.tsx
+++ b/frontend-react/src/pages/RegisterPage.tsx
@@ -57,6 +57,11 @@ export default function RegisterPage() {
         newErrors.push("パスワードとパスワード確認が一致していません")
       }
 
+      if (newErrors.length > 0) {
+        setErrors(newErrors)
+        return
+      }
+
       const userCredential = await createUserWithEmailAndPassword(auth, email, password)
       const user = userCredential.user
 

--- a/frontend-react/src/pages/RegisterPage.tsx
+++ b/frontend-react/src/pages/RegisterPage.tsx
@@ -1,5 +1,4 @@
 import InputField from "@/components/ui/InputField"
-import { RailsApiError } from "@/types"
 import { useState, useMemo } from "react"
 import { auth } from "@/lib/firebase"
 import { createUserWithEmailAndPassword } from "firebase/auth"
@@ -8,13 +7,14 @@ import { FirebaseError } from "firebase/app"
 import { useSetAuth } from "@/context/useAuthContext"
 import { useNavigate } from "react-router-dom"
 import getFirebaseErrorMessage from "@/lib/getFirebaseErrorMessage"
+import apiErrorHandler from "@/utils/apiErrorHandler"
 
 export default function RegisterPage() {
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [passwordConfirmation, setPasswordConfirmation] = useState("")
-  const [error, setError] = useState<string | null>(null)
+  const [errors, setErrors] = useState<string[]>([])
   const apiClient = useApiClient()
   const { setUser } = useSetAuth()
   const MIN_NAME_LENGTH = 2
@@ -34,33 +34,27 @@ export default function RegisterPage() {
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault()
+    const newErrors: string[] = []
 
     try {
-      setError(null)
+      setErrors([])
 
       if (name.length < MIN_NAME_LENGTH || name.length > MAX_NAME_LENGTH) {
-        setError(`名前は${MIN_NAME_LENGTH}文字以上${MAX_NAME_LENGTH}文字以内で入力してください。`)
-        return
+        newErrors.push(`名前は${MIN_NAME_LENGTH}文字以上${MAX_NAME_LENGTH}文字以内で入力してください。`)
       }
 
       if (!email.trim()) {
-        setError("メールアドレスを入力してください。")
-        return
+        newErrors.push("メールアドレスを入力してください。")
       }
 
       if (!password) {
-        setError("パスワードを入力してください。")
-        return
-      }
-
-      if (password.length < MIN_PASSWORD_LENGTH) {
-        setError(`パスワードは${MIN_PASSWORD_LENGTH}文字以上にしてください。`)
-        return
+        newErrors.push("パスワードを入力してください。")
+      } else if (password.length < MIN_PASSWORD_LENGTH) {
+        newErrors.push(`パスワードは${MIN_PASSWORD_LENGTH}文字以上にしてください。`)
       }
 
       if (password !== passwordConfirmation) {
-        setError("パスワードとパスワード確認が一致していません")
-        return
+        newErrors.push("パスワードとパスワード確認が一致していません")
       }
 
       const userCredential = await createUserWithEmailAndPassword(auth, email, password)
@@ -77,16 +71,9 @@ export default function RegisterPage() {
       navigate("/home")
     } catch (error: unknown) {
       if (error instanceof FirebaseError) {
-        setError(getFirebaseErrorMessage(error))
-      } else if ((error as RailsApiError).response?.status === 422) {
-        const errorData = (error as RailsApiError).response?.data
-        if (errorData?.errors?.email?.includes("このメールアドレスは既に存在します。")) {
-          setError("このメールアドレスは既に存在します。")
-        } else {
-          setError("このメールアドレスは登録できませんでした。再試行してください。")
-        }
+        setErrors([getFirebaseErrorMessage(error)])
       } else {
-        setError("予期しないエラーが発生しました。")
+        apiErrorHandler(error, setErrors)
       }
       setUser(null)
     }
@@ -149,9 +136,15 @@ export default function RegisterPage() {
               value={passwordConfirmation}
               onChange={(e) => setPasswordConfirmation(e.target.value)}
             />
-          {error && <div className="text-red-500 text-sm my-4">{error}</div>}
-          <button className="btn-ok my-4 md:mb-0 md:mr-4">登録する</button>
-        </form>
+            {errors.length > 0 && (
+                <div className="text-red-500 text-sm my-4">
+                  {errors.map((err, index) => (
+                    <div key={index}>{err}</div>
+                  ))}
+                </div>
+              )}
+            <button className="btn-ok my-4 md:mb-0 md:mr-4">登録する</button>
+          </form>
         </div>
         <button onClick={handleLoginClick} className="block mx-auto w-80 my-7 text-blue-600 border-4 border-violet-400 border-dashed outline-dashed px-0 py-2">
           アカウントをお持ちの方はこちら

--- a/frontend-react/src/pages/SendEmailPage.tsx
+++ b/frontend-react/src/pages/SendEmailPage.tsx
@@ -16,6 +16,11 @@ export default function ResetPassword() {
       newErrors.push("メールアドレスを入力してください。")
     }
 
+    if (newErrors.length > 0) {
+      setErrors(newErrors)
+      return
+    }
+
     try {
       setErrors([])
       const auth = getAuth()

--- a/frontend-react/src/pages/SendEmailPage.tsx
+++ b/frontend-react/src/pages/SendEmailPage.tsx
@@ -6,24 +6,26 @@ import InputField from "@/components/ui/InputField"
 
 export default function ResetPassword() {
   const [email, setEmail] = useState("")
-  const [error, setError] = useState<string | null>(null)
+  const [errors, setErrors] = useState<string[]>([])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    const newErrors: string[] = []
 
     if (!email.trim()) {
-      setError("メールアドレスを入力してください。")
-      return
+      newErrors.push("メールアドレスを入力してください。")
     }
 
     try {
-      setError(null)
+      setErrors([])
       const auth = getAuth()
 
       await sendPasswordResetEmail(auth, email)
       alert("再設定のご案内メールを送信しました。")
     } catch (error: unknown) {
-      setError(error instanceof FirebaseError ? getFirebaseErrorMessage(error) : "予期しないエラーが発生しました。")
+      setErrors([
+        error instanceof FirebaseError ? getFirebaseErrorMessage(error) : "予期しないエラーが発生しました。",
+      ])
     }
   }
 
@@ -39,13 +41,19 @@ export default function ResetPassword() {
           </p>
           <form className="text-center mx-7 md:mx-0" onSubmit={handleSubmit}>
             <InputField
-                label="メールアドレス"
-                type="email"
-                placeholder="メールアドレス"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
+              label="メールアドレス"
+              type="email"
+              placeholder="メールアドレス"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
             />
-            {error && <p className="ext-sm text-red-500 my-4">{error}</p>}
+            {errors.length > 0 && (
+              <div className="text-sm text-red-500 my-4">
+                {errors.map((err, index) => (
+                  <div key={index}>{err}</div>
+                ))}
+              </div>
+            )}
             <button className="btn-ok my-4 md:mb-0 md:mr-4">送信する</button>
           </form>
         </div>


### PR DESCRIPTION
### 概要
- エラーメッセージの管理方法を setError（単一の文字列）から setErrors（配列）に変更し、複数のエラーメッセージを適切に表示できるように修正しました。
また、APIエラーを統一的に処理するために apiErrorHandler を適用し、コードの一貫性と可読性を向上させました。

### 変更内容
- エラーの状態管理を setErrors（配列）に統一
- APIエラーを apiErrorHandler で処理
- Firebaseのエラーも配列として処理

close https://github.com/toshinori-m/stay_connect/issues/171