### PR TITLE
ホーム画面の検索・データ取得をカスタムフックに分離

### DIFF
--- a/frontend-react/src/hooks/search/useFetchInitialData.ts
+++ b/frontend-react/src/hooks/search/useFetchInitialData.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react"
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+
+interface UseFetchInitialDataProps {
+  setSportsTypes: (data: SelectOption[]) => void
+  setPrefectures: (data: SelectOption[]) => void
+  setTargetAges: (data: SelectOption[]) => void
+  setErrors: (errors: string[]) => void
+}
+
+export const useFetchInitialData = ({
+  setSportsTypes,
+  setPrefectures,
+  setTargetAges,
+  setErrors,
+}: UseFetchInitialDataProps) => {
+  const apiClient = useApiClient()
+
+  const fetchData = async () => {
+    try {
+      const [sportsRes, prefecturesRes, targetAgesRes] = await Promise.all([
+        apiClient.get("/sports_types"),
+        apiClient.get("/prefectures"),
+        apiClient.get("/target_ages"),
+      ])
+      setSportsTypes(sportsRes.data.data)
+      setPrefectures(prefecturesRes.data.data)
+      setTargetAges(targetAgesRes.data.data)
+    } catch {
+      setErrors(["競技・都道府県・対象年齢のデータ取得に失敗しました。時間を置いて再試行してください。"])
+    }
+  }
+
+  useEffect(() => {
+    fetchData()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+}

--- a/frontend-react/src/hooks/search/useFetchSportsDisciplines.ts
+++ b/frontend-react/src/hooks/search/useFetchSportsDisciplines.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react"
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+
+interface UseFetchSportsDisciplinesProps {
+  sportsTypeSelected: SelectOption | null
+  setSportsDisciplines: (data: SelectOption[]) => void
+  setSportsDisciplineSelected: (data: SelectOption | null) => void
+  setErrors: (errors: string[]) => void
+}
+
+export const useFetchSportsDisciplines = ({
+  sportsTypeSelected,
+  setSportsDisciplines,
+  setSportsDisciplineSelected,
+  setErrors,
+}: UseFetchSportsDisciplinesProps) => {
+  const apiClient = useApiClient()
+
+  const fetchSportsTypes = async () => {
+    try {
+      if (!sportsTypeSelected) {
+        setSportsDisciplines([])
+        setSportsDisciplineSelected(null)
+        return
+      }
+
+      const params = { sports_type_id: sportsTypeSelected.id }
+      const res = await apiClient.get("/sports_disciplines", { params })
+      setSportsDisciplines(res.data.data)
+    } catch {
+      setErrors(["スポーツ種目のデータ取得に失敗しました。時間を置いて再試行してください。"])
+    }
+  }
+
+  useEffect(() => {
+    fetchSportsTypes()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sportsTypeSelected])
+}

--- a/frontend-react/src/hooks/search/useInitialSearch.ts
+++ b/frontend-react/src/hooks/search/useInitialSearch.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react"
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+import { Recruitment } from "@/types"
+
+interface UseInitialSearchProps {
+  setRecruitments: (data: Recruitment[]) => void
+  setErrors: (errors: string[]) => void
+}
+
+export const useInitialSearch = ({
+  setRecruitments,
+  setErrors,
+}: UseInitialSearchProps) => {
+  const apiClient = useApiClient()
+
+  const handleSearch = async (
+    sportsType: SelectOption | null,
+    sportsDiscipline: SelectOption | null,
+    prefecture: SelectOption | null,
+    targetAge: SelectOption | null
+  ) => {
+    try {
+      setErrors([])
+      setRecruitments([])
+
+      const params = {
+        sports_type_name: sportsType?.name || "",
+        prefecture_name: prefecture?.name || "",
+        target_age_name: targetAge?.name || "",
+        sports_discipline_name: sportsDiscipline?.name || "",
+      }
+
+      const res = await apiClient.get("/searches", { params })
+      setRecruitments(res.data)
+    } catch {
+      setErrors(["イベントのデータ取得に失敗しました。時間を置いて再試行してください。"])
+    }
+  }
+
+  useEffect(() => {
+    const sportsType = null
+    const  sportsDiscipline = null
+    const prefecture = null
+    const targetAge = null
+    
+    handleSearch(sportsType , sportsDiscipline, prefecture, targetAge)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { handleSearch }
+}

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -14,3 +14,18 @@ export interface SelectOption {
   id: number
   name: string
 }
+
+// イベント検索API（/searches）から取得するデータの型
+export interface Recruitment {
+  id: number
+  name: string
+  prefecture_name: string
+  area: string
+  purpose_body: string
+  sex: string
+  sports_type_name: string
+  sports_discipline_name: { id: number; name: string }[]
+  target_age_name: { id: number; name: string }[]
+  start_date: string
+  end_date: string
+}


### PR DESCRIPTION
## 概要
- HomePage に含まれていたデータ取得系のuseEffectをそれぞれカスタムフックに分離しました。
  - useFetchInitialData
  - useFetchSportsDisciplines
  - useInitialSearch
## 目的
- コンポーネントの責務を分離し、可読性・保守性向上
## 動作確認
- フォーム初期表示時に正しく選択肢が取得
- 条件なしで初期イベント検索が行われ表示
- 各セレクトボックス選択後の再検索で結果が正しく表示


close https://github.com/toshinori-m/stay_connect/issues/188