### PR TITLE
イベント設定ページの初期UIとデータ取得ロジックの実装（競技種別・種目・都道府県・対象年齢・イベント名・イベントURL・地域・性別）

### DIFF
--- a/frontend-react/src/components/layout/HomeHeader.tsx
+++ b/frontend-react/src/components/layout/HomeHeader.tsx
@@ -39,7 +39,7 @@ export default function HomeHeader() {
   const goToChatRoomList = () => console.log("チャットルーム一覧画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
   const menuItems = [
   { label: "ホーム", onClick: () => navigate("/home") },
-  { label: "イベント作成", onClick: () => console.log("イベント作成画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加
+  { label: "イベント作成", onClick: () => navigate("/event_setting") },
   { label: "イベント一覧", onClick: () => console.log("イベント一覧画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加
   { label: "基本設定", onClick: () => console.log("基本設定画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加
   { label: "チーム紹介一覧", onClick: () => console.log("チーム紹介一覧画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加

--- a/frontend-react/src/components/ui/SelectField.tsx
+++ b/frontend-react/src/components/ui/SelectField.tsx
@@ -1,0 +1,58 @@
+import React, { ReactNode } from "react"
+import { SelectOption } from "@/types"
+
+interface SelectFieldProps {
+  label?: ReactNode
+  value: string | number | string[]  
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
+  options: SelectOption[]
+  placeholder?: string
+  className?: string
+  multiple?: boolean  
+}
+
+const renderPlaceholderOption = (multiple: boolean, placeholder: string) => {
+  if (multiple) return null
+  return (
+    <option disabled value="">
+      {placeholder}
+    </option>
+  )
+}
+
+const renderOptions = (options: SelectOption[]) => {
+  return options.map((opt) => (
+    <option key={opt.id} value={opt.id}>
+      {opt.name}
+    </option>
+  ))
+}
+
+export default function SelectField({
+  label,
+  value,
+  onChange,
+  options,
+  placeholder = "1つを選択して下さい",
+  className = "",
+  multiple = false
+}: SelectFieldProps) {
+  return (
+    <div className="w-full md:flex md:px-8 items-center">
+      {label && (
+        <p className="w-40 md:-ml-3 pl-2 tracking-tighter text-sm">
+          {label}
+        </p>
+      )}
+      <select
+        value={value}
+        onChange={onChange}
+        multiple={multiple}
+        className={`w-full py-3 px-1.5 my-2 border-2 border-gray-200 ${className}`}
+      >
+        {renderPlaceholderOption(multiple, placeholder)}
+        {renderOptions(options)}
+      </select>
+    </div>
+  )
+}

--- a/frontend-react/src/components/ui/TextareaField.tsx
+++ b/frontend-react/src/components/ui/TextareaField.tsx
@@ -1,34 +1,34 @@
 import { ReactNode } from "react"
 
-interface InputFieldProps {
+interface TextareaFieldProps {
   label: ReactNode
-  type?: "text" | "email" | "password" | "url" | "radio"
   placeholder?: string
   value: string
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
   required?: boolean
   className?: string
+  rows?: number
 }
 
-export default function InputField({ 
+export default function TextareaField({
   label,
-  type,
   placeholder = "",
   value,
   onChange,
   required = false,
-  className = ""
-}: InputFieldProps) {
+  className = "",
+  rows = 4,
+}: TextareaFieldProps) {
   return (
     <div className="w-full md:flex md:px-8 items-center">
       <p className="w-40 md:-ml-3 pl-2 tracking-tighter text-sm">{label}</p>
-      <input
-        className={`w-full py-3 px-1.5 my-2 border-2 border-gray-200 ${className}`}
-        type={type}
+      <textarea
+        className={`w-full py-3 px-1.5 my-2 border-2 border-gray-200 resize-none ${className}`}
         placeholder={placeholder}
         value={value}
         onChange={onChange}
         required={required}
+        rows={rows}
       />
     </div>
   )

--- a/frontend-react/src/hooks/search/useFetchDisciplines.ts
+++ b/frontend-react/src/hooks/search/useFetchDisciplines.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+
+export default function useFetchDisciplines(sportsTypeSelected: SelectOption | null) {
+  const apiClient = useApiClient()
+  const [sportsDisciplines, setSportsDisciplines] = useState<SelectOption[]>([])
+  const [errors, setErrors] = useState<string[]>([])
+
+  const fetchDisciplines = async () => {
+    if (!sportsTypeSelected) {
+      setSportsDisciplines([])
+      return
+    }
+    try {
+      const res = await apiClient.get("/sports_disciplines", {
+        params: { sports_type_id: sportsTypeSelected.id },
+      })
+      setSportsDisciplines(res.data.data)
+    } catch {
+      setErrors(["スポーツ種目のデータ取得に失敗しました。時間を置いて再試行してください。"])
+    }
+  }
+
+  useEffect(() => {
+    fetchDisciplines()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sportsTypeSelected])
+
+  return { sportsDisciplines, errors }
+}

--- a/frontend-react/src/hooks/search/useInitialFormData.ts
+++ b/frontend-react/src/hooks/search/useInitialFormData.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react"
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+
+export default function useInitialFormData() {
+  const [sportsTypes, setSportsTypes] = useState<SelectOption[]>([])
+  const [prefectures, setPrefectures] = useState<SelectOption[]>([])
+  const [targetAges, setTargetAges] = useState<SelectOption[]>([])
+  const [errors, setErrors] = useState<string[]>([])
+  const apiClient = useApiClient()
+
+  const fetchData = async () => {
+    try {
+      setErrors([])
+      const [sportsRes, prefecturesRes, targetAgesRes] = await Promise.all([
+        apiClient.get("/sports_types"),
+        apiClient.get("/prefectures"),
+        apiClient.get("/target_ages"),
+      ])
+      setSportsTypes(sportsRes.data.data)
+      setPrefectures(prefecturesRes.data.data)
+      setTargetAges(targetAgesRes.data.data)
+    } catch {
+      setErrors(["初期データの取得に失敗しました。時間を置いて再試行してください。"])
+    }
+  }
+
+  useEffect(() => {
+    fetchData()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { sportsTypes, prefectures, targetAges, errors }
+}

--- a/frontend-react/src/pages/eventPages/EventSettingPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingPage.tsx
@@ -1,0 +1,277 @@
+import { useState, useEffect } from "react"
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+
+export default function EventSettingPage() {
+  const [sportsTypes, setSportsTypes] = useState<SelectOption[]>([])
+  const [sportsTypeSelected, setSportsTypeSelected] = useState<SelectOption | null>(null)
+  const [sportsDisciplines, setSportsDisciplines] = useState<SelectOption[]>([])
+  const [sportsDisciplineSelected, setSportsDisciplineSelected] = useState<SelectOption[]>([])
+
+  const [eventUrl, setEventUrl] = useState("")
+  const [eventName, setEventName] = useState("")
+  const [area, setArea] = useState("")
+  const [sex, setSex] = useState("")
+
+  const [prefectures, setPrefectures] = useState<SelectOption[]>([])
+  const [prefectureSelected, setPrefectureSelected] = useState<string | null>(null)
+
+  const [targetAges, setTargetAges] = useState<SelectOption[]>([])
+  const [targetAgeSelected, setTargetAgeSelected] = useState<SelectOption[]>([])
+
+  const [errors, setErrors] = useState<string[]>([])
+  const apiClient = useApiClient()
+  const remainingCharacters = (input: string) => MAX_LENGTH - input.length
+
+
+  const fetchData = async () => {
+    try {
+      setErrors([])
+
+      const [sportsRes, prefecturesRes, targetAgesRes] = await Promise.all([
+        apiClient.get("/sports_types"),
+        apiClient.get("/prefectures"),
+        apiClient.get("/target_ages"),
+      ])
+
+      setSportsTypes(sportsRes.data.data)
+      setPrefectures(prefecturesRes.data.data)
+      setTargetAges(targetAgesRes.data.data)
+    } catch {
+      setErrors(["競技・都道府県・対象年齢のデータ取得に失敗しました。時間を置いて再試行してください。"])
+    }
+  }
+
+  useEffect(() => {
+    fetchData()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const fetchSportsTypes = async () => {
+    try {
+      if (!sportsTypeSelected) {
+        setSportsDisciplines([])
+        setSportsDisciplineSelected([])
+        return
+      }
+      const params = { sports_type_id: sportsTypeSelected.id }
+      const res = await apiClient.get("/sports_disciplines", { params })
+      setSportsDisciplines(res.data.data)
+    } catch {
+      setErrors(["スポーツ種目のデータ取得に失敗しました。時間を置いて再試行してください。"])
+    }
+  }
+
+  useEffect(() => {
+    fetchSportsTypes()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sportsTypeSelected])
+
+  const selectFields: {
+    label: React.ReactNode
+    options: SelectOption[]
+    selected: unknown
+    setSelected: (value: unknown) => void
+    isMultiple?: boolean
+    show?: boolean
+  }[] = [
+    {
+      label: "競技選択",
+      options: sportsTypes,
+      selected: sportsTypeSelected,
+      setSelected: (value) => setSportsTypeSelected(value as SelectOption | null)
+    },
+    {
+      label: (
+        <>
+          種目選択<br/>（複数可）
+        </>
+      ),
+      options: sportsDisciplines,
+      selected: sportsDisciplineSelected,
+      setSelected: (value) => setSportsDisciplineSelected(value as SelectOption[]),
+      isMultiple: true,
+      show: sportsDisciplines.length > 0
+    },
+    {
+      label: "都道府県選択",
+      options: prefectures,
+      selected: prefectureSelected,
+      setSelected: (value) => setPrefectureSelected(value as string)
+    },
+    {
+      label:(
+        <>
+          対象年齢選択<br/>（複数可）
+        </>
+      ),
+      options: targetAges,
+      selected: targetAgeSelected,
+      setSelected: (value) => setTargetAgeSelected(value as SelectOption[]),
+      isMultiple: true
+    }
+  ]
+
+  const inputFields: {
+    label: React.ReactNode,
+    type: "text" | "url" | "textarea",
+    value: string,
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void,
+    placeholder: string,
+    showLimit?: boolean
+  }[] = [
+    {
+      label: "イベント名",
+      type: "text",
+      value: eventName,
+      onChange: (e) => setEventName(e.target.value),
+      placeholder: "イベント名",
+      showLimit: true
+    },
+    {
+      label: "イベントURL",
+      type: "url",
+      value: eventUrl,
+      onChange: (e) => setEventUrl(e.target.value),
+      placeholder: "https://www.example.com/images/example.jpg"
+    },
+    {
+      label:(
+        <>
+          地域<br/>（255文字まで）
+        </>
+      ),
+      type: "textarea",
+      value: area,
+      onChange: (e) => setArea(e.target.value),
+      placeholder: "イベント開催場所",
+      showLimit: true
+    }
+  ]
+
+  const radioFields = [
+    {
+      label: "性別",
+      options: [
+        { value: "man", label: "男" },
+        { value: "woman", label: "女" },
+        { value: "mix", label: "男女" },
+        { value: "man_and_woman", label: "混合" },
+      ],
+      selected: sex,
+      setSelected: setSex,
+    },
+  ]
+
+  const SHOW_LIMIT_THRESHOLD = 5
+  const MAX_LENGTH = 255
+
+  return (
+    <div className="flex items-center justify-center mt-32 md:mt-20">
+      <div className="w-full md:w-3/5 xl:w-2/5 shadow-gray-200 bg-sky-100 rounded-lg">
+        <h2 className="text-center mb-10 pt-10 font-bold text-3xl text-blue-600">イベント設定</h2>
+        <form className="px-4 md:px-0 text-center" onSubmit={(e) => e.preventDefault()}>
+          <ul className="space-y-4 text-left">
+            {selectFields.map(({ label, options, selected, setSelected, isMultiple = false, show = true }, index) =>
+              show ? (
+                <li key={index} className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                  <label className="md:col-span-4 px-3 py-2">{label}</label>
+                  <div className="md:col-span-8">
+                    <select
+                      multiple={isMultiple}
+                      value={
+                        isMultiple
+                          ? (selected as SelectOption[]).map((s) => s.id.toString())
+                          : (selected as SelectOption)?.id?.toString() || ""
+                      }
+                      onChange={(e) => {
+                        if (isMultiple) {
+                          const selectedIds = Array.from(e.target.selectedOptions).map((opt) => opt.value)
+                          const filtered = (options as SelectOption[]).filter((opt) =>
+                            selectedIds.includes(opt.id.toString())
+                          )
+                          setSelected(filtered)
+                        } else {
+                          const option = (options as SelectOption[]).find(
+                            (opt) => opt.id.toString() === e.target.value
+                          ) || null
+                          setSelected(option)
+                        }
+                      }}
+                      className="w-full py-2 px-3 border-2 border-gray-200 rounded-lg"
+                    >
+                      {!isMultiple && <option value="">{label}</option>}
+                      {options.map((opt) => (
+                        <option key={opt.id} value={opt.id.toString()}>{opt.name}</option>
+                      ))}
+                    </select>
+                    {isMultiple && (selected as SelectOption[]).length > 0 && (
+                      <div className="mt-2 py-2 px-3 border-2 border-gray-200 rounded-lg bg-white text-gray-700">
+                        {(selected as SelectOption[]).map((s) => s.name).join(", ")}
+                      </div>
+                    )}
+                  </div>
+                </li>
+              ) : null
+            )}
+
+            {inputFields.map(({ label, type, value, onChange, placeholder, showLimit }, index) => (
+              <li key={index} className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <label className="md:col-span-4 px-3 py-2">{label}</label>
+                <div className="md:col-span-8">
+                  {type === "textarea" ? (
+                    <textarea
+                      value={value}
+                      onChange={onChange}
+                      placeholder={placeholder}
+                      className="w-full h-32 py-2 px-3 border-2 border-gray-200 rounded-lg"
+                    />
+                  ) : (
+                    <input
+                      type={type}
+                      value={value}
+                      onChange={onChange}
+                      placeholder={placeholder}
+                      className="w-full py-2 px-3 border-2 border-gray-200 rounded-lg"
+                    />
+                  )}
+                  {showLimit && remainingCharacters(value) <= SHOW_LIMIT_THRESHOLD && (
+                    <div className="text-red-500 text-sm">{label}はあと{remainingCharacters(value)}文字までです。</div>
+                  )}
+                </div>
+              </li>
+            ))}
+
+            {radioFields.map(({ label, options, selected, setSelected }, index) => (
+              <li key={index} className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <label className="md:col-span-4 px-3 py-2">{label}</label>
+                <div className="md:col-span-8 grid grid-cols-4 gap-2">
+                  {options.map((opt) => (
+                    <label key={opt.value}>
+                      <input
+                        type="radio"
+                        value={opt.value}
+                        checked={selected === opt.value}
+                        onChange={(e) => setSelected(e.target.value)}
+                        className="mr-1"
+                      />
+                      {opt.label}
+                    </label>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </form>
+
+        {errors.length > 0 && (
+          <div className="text-red-500 text-sm mt-2">
+            {errors.map((error, index) => (
+              <li key={index}>{error}</li>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -9,6 +9,7 @@ import LoginPage from "@/pages/LoginPage"
 import SignupPage from "@/pages/SignupPage"
 import RegisterPage from "@/pages/RegisterPage"
 import HomePage from "@/pages/HomePage"
+import EventSettingPage from "@/pages/eventPages/EventSettingPage"
 
 function OpenLayout() {
   return (
@@ -57,6 +58,7 @@ export default function AppRouter() {
       <Route element={<RequireAuth />}>
         <Route element={<HomeLayout />}>
           <Route path="/home" element={<HomePage />} />
+          <Route path="/event_setting" element={<EventSettingPage />} />
         </Route>
       </Route>
     </Routes>


### PR DESCRIPTION
### 概要
イベント設定ページの初期UIを構築し、必要なデータ（競技種別、種目、都道府県、対象年齢）を取得するロジックを実装しました。本PRは、2回に分けて行う実装の第1段階です。

### 変更内容
- EventSettingPage.tsx を新規作成
- 以下のフォーム項目をUIとして追加
  - 競技種別（単一選択）
  - 種目（複数選択）
  - 都道府県（単一選択）
  - 対象年齢（複数選択）
  - イベント名（テキスト入力）
  - イベントURL（URL入力）
  - 地域（テキストエリア）
  - 性別（ラジオボタン）
- エラー時のメッセージ表示を実装
- 文字数制限に応じた警告表示を実装（イベント名、地域）

close https://github.com/toshinori-m/stay_connect/issues/189