### PR TITLE
イベント一覧ページを新規作成

### DIFF
--- a/backend/app/controllers/recruitments_controller.rb
+++ b/backend/app/controllers/recruitments_controller.rb
@@ -29,9 +29,9 @@ class RecruitmentsController < ApplicationController
   end
 
   def destroy
-    recruitment = Recruitment.find(params[:id])
+    recruitment = current_user.recruitments.find(params[:id])
     recruitment.destroy!
-    @recruitments = current_user.recruitment.preload(:sports_disciplines, :target_ages)
+    @recruitments = current_user.recruitments.preload(:sports_disciplines, :target_ages)
   rescue ActiveRecord::RecordNotFound => e
     render json: { error: '対象の募集が見つかりません。' }, status: :not_found
   rescue ActiveRecord::RecordNotDestroyed => e

--- a/frontend-react/src/components/layout/HomeHeader.tsx
+++ b/frontend-react/src/components/layout/HomeHeader.tsx
@@ -40,7 +40,7 @@ export default function HomeHeader() {
   const menuItems = [
   { label: "ホーム", onClick: () => navigate("/home") },
   { label: "イベント作成", onClick: () => navigate("/event_setting") },
-  { label: "イベント一覧", onClick: () => console.log("イベント一覧画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加
+  { label: "イベント一覧", onClick: () => navigate("/event_setting_list") },
   { label: "基本設定", onClick: () => console.log("基本設定画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加
   { label: "チーム紹介一覧", onClick: () => console.log("チーム紹介一覧画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加
   { label: "ログアウト", onClick: logOut, extraClass: "ml-2 lg:-mr-7" }

--- a/frontend-react/src/pages/eventPages/EventSettingListPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingListPage.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+
+export default function EventList() {
+  const [recruitments, setRecruitments] = useState<SelectOption[]>([])
+  const [errors, setErrors] = useState<string[]>([])
+  const apiClient = useApiClient()
+
+  const getRecruitment = async () => {
+    setErrors([])
+    try {
+      const res = await apiClient.get('/recruitments')
+      setRecruitments(res.data.data)
+    } catch {
+      setErrors(["イベントを表示できませんでした。"])
+    }
+  }
+
+  useEffect(() => {
+    getRecruitment()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const editRecruitment = () => {
+    console.log("イベント編集画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  }
+
+  const deleteRecruitment = async (id: number) => {
+    setErrors([])
+    try {
+      const res = await apiClient.delete(`/recruitments/${id}`)
+      setRecruitments(res.data)
+    } catch {
+      setErrors(["イベントを削除できませんでした。"])
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center mt-32 md:mt-20">
+      <div className="w-full md:w-3/5 xl:w-2/5 pb-7 shadow-gray-200 bg-sky-100 rounded-lg">
+        <h2 className="text-center mb-7 pt-10 font-bold text-3xl text-blue-600">イベント一覧</h2>
+        <div className="flex flex-col items-center">
+          {errors.length > 0 && (
+            <div className="text-red-500 text-sm my-4">
+              {errors.map((err, index) => ( <div key={index}>{err}</div> ))}
+            </div>
+          )}
+
+          {recruitments.map((SelectOption) => (
+            <div
+              key={SelectOption.id}
+              className="text-left my-3 sm:ml-4 sm:mr-6 w-72 p-4 ring-offset-2 ring-2 rounded-lg break-words"
+            >
+              イベント名: {SelectOption.name}
+              <div className="flex justify-center mt-5">
+                {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
+                <button className="update_button" onClick={() => editRecruitment()}>更新</button>
+                <button className="delete_button mx-5" onClick={() => deleteRecruitment(SelectOption.id)}>削除</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/eventPages/EventSettingListPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingListPage.tsx
@@ -7,6 +7,11 @@ export default function EventList() {
   const [errors, setErrors] = useState<string[]>([])
   const apiClient = useApiClient()
 
+  useEffect(() => {
+    getRecruitment()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const getRecruitment = async () => {
     setErrors([])
     try {
@@ -16,11 +21,6 @@ export default function EventList() {
       setErrors(["イベントを表示できませんでした。"])
     }
   }
-
-  useEffect(() => {
-    getRecruitment()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   const editRecruitment = () => {
     console.log("イベント編集画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
@@ -47,16 +47,16 @@ export default function EventList() {
             </div>
           )}
 
-          {recruitments.map((SelectOption) => (
+          {recruitments.map((recruitment) => (
             <div
-              key={SelectOption.id}
+              key={recruitment.id}
               className="text-left my-3 sm:ml-4 sm:mr-6 w-72 p-4 ring-offset-2 ring-2 rounded-lg break-words"
             >
-              イベント名: {SelectOption.name}
+              イベント名: {recruitment.name}
               <div className="flex justify-center mt-5">
                 {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
                 <button className="update_button" onClick={() => editRecruitment()}>更新</button>
-                <button className="delete_button mx-5" onClick={() => deleteRecruitment(SelectOption.id)}>削除</button>
+                <button className="delete_button mx-5" onClick={() => deleteRecruitment(recruitment.id)}>削除</button>
               </div>
             </div>
           ))}

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -10,6 +10,7 @@ import SignupPage from "@/pages/SignupPage"
 import RegisterPage from "@/pages/RegisterPage"
 import HomePage from "@/pages/HomePage"
 import EventSettingPage from "@/pages/eventPages/EventSettingPage"
+import EventSettingListPage from "@/pages/eventPages/EventSettingListPage"
 
 function OpenLayout() {
   return (
@@ -59,6 +60,7 @@ export default function AppRouter() {
         <Route element={<HomeLayout />}>
           <Route path="/home" element={<HomePage />} />
           <Route path="/event_setting" element={<EventSettingPage />} />
+          <Route path="/event_setting_list" element={<EventSettingListPage />} />
         </Route>
       </Route>
     </Routes>


### PR DESCRIPTION
## 変更内容
- `EventSettingListPage.tsx` を新規作成
- エラー表示や削除・編集ボタンの機能もReact側で再現
- `useNavigate` によりページ遷移を対応
## 動作確認
- 「削除」ボタンにて指定のイベントを削除
## 備考
- 「編集」ボタンからイベント編集画面への遷移は他のissueにて修正予定です。
- 「編集」「削除」ボタンは下のprをマージ次第修正予定です。
  - [イベント設定ページに開始・終了日付、募集チーム数、目的・その他入力欄を追加 ](https://github.com/toshinori-m/stay_connect/pull/199)

close https://github.com/toshinori-m/stay_connect/issues/190