### PR TITLE
チーム紹介一覧ページを新規作成

### DIFF
--- a/frontend-react/src/components/layout/HomeHeader.tsx
+++ b/frontend-react/src/components/layout/HomeHeader.tsx
@@ -42,7 +42,7 @@ export default function HomeHeader() {
   { label: "イベント作成", onClick: () => navigate("/event_setting") },
   { label: "イベント一覧", onClick: () => navigate("/event_setting_list") },
   { label: "基本設定", onClick: () => console.log("基本設定画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加
-  { label: "チーム紹介一覧", onClick: () => console.log("チーム紹介一覧画面は次のissueで作成予定！") }, // TODO: 後続タスクで処理を追加
+  { label: "チーム紹介一覧", onClick: () => navigate("/team_profile_list") },
   { label: "ログアウト", onClick: logOut, extraClass: "ml-2 lg:-mr-7" }
 ]
 

--- a/frontend-react/src/components/ui/Button.tsx
+++ b/frontend-react/src/components/ui/Button.tsx
@@ -10,6 +10,8 @@ export default function Button({ variant = "primary", size = "sm", className, ch
   const variantClass = {
     primary: "btn-primary",
     ghost: "btn-ghost",
+    yellow: "btn-yellow",
+    red: "btn-red",
   }[variant]
 
   const sizeClass = {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -20,6 +20,7 @@ body {
   }
 
   /* 色・役割 */
+    /* Primary button */
   .btn-primary {
     @apply text-white bg-blue-700 
            shadow-[inset_2px_2px_3px_rgba(255,255,255,0.6),inset_-2px_-2px_3px_rgba(0,0,0,0.6)];
@@ -31,6 +32,7 @@ body {
     @apply shadow-[inset_-2px_-2px_3px_rgba(255,255,255,0.6),inset_2px_2px_3px_rgba(0,0,0,0.6)];
   }
   
+    /* Ghost button */
   .btn-ghost {
     @apply text-black bg-white 
            shadow-[inset_2px_2px_3px_rgba(255,255,255,0.6),inset_-2px_-2px_3px_rgba(0,0,0,0.6)];
@@ -38,5 +40,28 @@ body {
   .btn-ghost:hover {
     @apply bg-gray-500 text-white;
   }
-    
+
+    /* Yellow button */
+  .btn-yellow {
+    @apply text-white bg-yellow-700
+           shadow-[inset_2px_2px_3px_rgba(255,255,255,0.6),inset_-2px_-2px_3px_rgba(0,0,0,0.6)];
+  }
+  .btn-yellow:hover {
+    @apply bg-yellow-500;
+  }
+  .btn-yellow:active {
+    @apply shadow-[inset_-2px_-2px_3px_rgba(255,255,255,0.6),inset_2px_2px_3px_rgba(0,0,0,0.6)];
+  }
+
+  /* Red button */
+  .btn-red {
+    @apply text-white bg-red-700
+           shadow-[inset_2px_2px_3px_rgba(255,255,255,0.6),inset_-2px_-2px_3px_rgba(0,0,0,0.6)];
+  }
+  .btn-red:hover {
+    @apply bg-pink-500;
+  }
+  .btn-red:active {
+    @apply shadow-[inset_-2px_-2px_3px_rgba(255,255,255,0.6),inset_2px_2px_3px_rgba(0,0,0,0.6)];
+  }
 }

--- a/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import { SelectOption } from "@/types"
+import { useApiClient } from "@/hooks/useApiClient"
+
+export default function TeamProfileList() {
+  const [teams, setTeams] = useState<SelectOption[]>([])
+  const [errors, setErrors] = useState<string[]>([])
+  const maxTeamsAllowed = 5
+  const apiClient = useApiClient()
+
+  useEffect(() => {
+    getTeamProfile()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const getTeamProfile = async () => {
+    try {
+      setErrors([])
+      const res = await apiClient.get('/teams')
+      setTeams(res.data.data)
+    } catch {
+      setErrors(["チーム名を表示できませんでした。"])
+    }
+  }
+
+  const editTeamProfile = () => {
+    console.log("チーム紹介編集画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  }
+
+  const deleteTeamProfile = () => {
+    console.log("チーム紹介削除は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  }
+
+  const createTeamProfile = () => {
+    console.log("チーム紹介作成画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  }
+
+  return (
+    <div className="flex items-center justify-center mt-32 md:mt-20">
+      <div className="w-full md:w-3/5 xl:w-2/5 pb-7 shadow-gray-200 bg-sky-100 rounded-lg">
+        <h2 className="text-center mb-7 pt-10 font-bold text-3xl text-blue-600">チーム紹介一覧</h2>
+        <div className="flex justify-center">
+           {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
+          <button
+            className="ml-2 mr-1"
+            onClick={createTeamProfile}
+            disabled={teams.length >= maxTeamsAllowed}
+          >
+            チーム紹介作成
+            <br />
+            （最大5チームまで）
+          </button>
+        </div>
+        <div className="flex flex-col items-center">
+          {errors.length > 0 && (
+            <div className="text-red-500 text-sm my-4">
+              {errors.map((err, index) => ( <div key={index}>{err}</div> ))}
+            </div>
+          )}
+          <div className="flex flex-col items-center mt-10 mb-10">
+            {teams.map((team) => (
+              <div
+                key={team.id}
+                className="text-left my-3 sm:ml-4 sm:mr-6 w-72 pt-3 ring-offset-2 ring-2 rounded-lg break-words"
+              >
+                チーム名: {team.name}
+                <div className="flex justify-center">
+                  {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
+                  <button className="" onClick={() => editTeamProfile()}>更新</button>
+                  {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
+                  <button className=" mx-5" onClick={() => deleteTeamProfile()}>削除</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { SelectOption } from "@/types"
 import { useApiClient } from "@/hooks/useApiClient"
+import Button from "@/components/ui/Button"
 
 export default function TeamProfileList() {
   const [teams, setTeams] = useState<SelectOption[]>([])
@@ -40,8 +41,9 @@ export default function TeamProfileList() {
       <div className="w-full md:w-3/5 xl:w-2/5 pb-7 shadow-gray-200 bg-sky-100 rounded-lg">
         <h2 className="text-center mb-7 pt-10 font-bold text-3xl text-blue-600">チーム紹介一覧</h2>
         <div className="flex justify-center">
-           {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
-          <button
+          <Button
+            variant="primary"
+            size="sm"
             className="ml-2 mr-1"
             onClick={createTeamProfile}
             disabled={teams.length >= MAX_TEAM_NUMBER}
@@ -49,7 +51,7 @@ export default function TeamProfileList() {
             チーム紹介作成
             <br />
             （最大5チームまで）
-          </button>
+          </Button>
         </div>
         <div className="flex flex-col items-center">
           {errors.length > 0 && (
@@ -65,10 +67,8 @@ export default function TeamProfileList() {
               >
                 チーム名: {team.name}
                 <div className="flex justify-center">
-                  {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
-                  <button className="" onClick={() => editTeamProfile()}>更新</button>
-                  {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
-                  <button className=" mx-5" onClick={() => deleteTeamProfile()}>削除</button>
+                  <Button variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4" onClick={() => editTeamProfile()}>修正</Button>
+                  <Button variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4" onClick={() => deleteTeamProfile()}>削除</Button>
                 </div>
               </div>
             ))}

--- a/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
@@ -5,7 +5,7 @@ import { useApiClient } from "@/hooks/useApiClient"
 export default function TeamProfileList() {
   const [teams, setTeams] = useState<SelectOption[]>([])
   const [errors, setErrors] = useState<string[]>([])
-  const maxTeamsAllowed = 5
+  const MAX_TEAM_NUMBER = 5
   const apiClient = useApiClient()
 
   useEffect(() => {
@@ -44,7 +44,7 @@ export default function TeamProfileList() {
           <button
             className="ml-2 mr-1"
             onClick={createTeamProfile}
-            disabled={teams.length >= maxTeamsAllowed}
+            disabled={teams.length >= MAX_TEAM_NUMBER}
           >
             チーム紹介作成
             <br />

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -11,6 +11,7 @@ import RegisterPage from "@/pages/RegisterPage"
 import HomePage from "@/pages/HomePage"
 import EventSettingPage from "@/pages/eventPages/EventSettingPage"
 import EventSettingListPage from "@/pages/eventPages/EventSettingListPage"
+import TeamProfileListPage from "@/pages/teamPages/TeamProfileListPage"
 
 function OpenLayout() {
   return (
@@ -61,6 +62,7 @@ export default function AppRouter() {
           <Route path="/home" element={<HomePage />} />
           <Route path="/event_setting" element={<EventSettingPage />} />
           <Route path="/event_setting_list" element={<EventSettingListPage />} />
+          <Route path="/team_profile_list" element={<TeamProfileListPage />} />
         </Route>
       </Route>
     </Routes>


### PR DESCRIPTION
## 変更内容
- `TeamProfileList.tsx` を新規作成
## 備考
- 「作成」ボタンからイベント編集画面への遷移は他のissueにて修正予定です。
- 「更新」ボタンからイベント編集画面への遷移は他のissueにて修正予定です。
- 「作成」「更新」「削除」ボタンは下のprをマージ次第修正予定です。
  - [イベント設定ページに開始・終了日付、募集チーム数、目的・その他入力欄を追加 ](https://github.com/toshinori-m/stay_connect/pull/199)

close https://github.com/toshinori-m/stay_connect/issues/204