### PR TITLE
チャットルーム一覧ページを新規作成

### DIFF
--- a/frontend-react/src/components/layout/HomeHeader.tsx
+++ b/frontend-react/src/components/layout/HomeHeader.tsx
@@ -36,7 +36,7 @@ export default function HomeHeader() {
   }
 
   const goToHome = () => navigate("/home")
-  const goToChatRoomList = () => console.log("チャットルーム一覧画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  const goToChatRoomList = () => navigate("/chat_room_list")
   const menuItems = [
   { label: "ホーム", onClick: () => navigate("/home") },
   { label: "イベント作成", onClick: () => navigate("/event_setting") },

--- a/frontend-react/src/components/ui/Button.tsx
+++ b/frontend-react/src/components/ui/Button.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import clsx from "clsx"
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "primary" | "ghost"
+  variant?: "primary" | "ghost" | "yellow" | "red"
   size?: "lg" | "sm"
 }
 

--- a/frontend-react/src/pages/chatPage/ChatRoomListPage.tsx
+++ b/frontend-react/src/pages/chatPage/ChatRoomListPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useApiClient } from "@/hooks/useApiClient"
 import { SelectOption } from "@/types"
+import Button from "@/components/ui/Button"
 
 export default function ChatRoomListPage() {
   const [chatRooms, setChatRooms] = useState<SelectOption[]>([])
@@ -48,9 +49,8 @@ export default function ChatRoomListPage() {
             >
               チャット名: {chatRoom.name}
               <div className="flex justify-center mt-5">
-                {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
-                <button className="update_button" onClick={() => editChatRoom()}>連絡</button>
-                <button className="delete_button mx-5" onClick={() => deleteChatRoom()}>削除</button>
+                <Button variant="yellow" size="sm" className="my-4 md:mb-0 md:mr-4" onClick={() => editChatRoom()}>連絡</Button>
+                <Button variant="red" size="sm" className="my-4 md:mb-0 md:mr-4" onClick={() => deleteChatRoom()}>削除</Button>
               </div>
             </div>
           ))}

--- a/frontend-react/src/pages/chatPage/ChatRoomListPage.tsx
+++ b/frontend-react/src/pages/chatPage/ChatRoomListPage.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+
+export default function ChatRoomListPage() {
+  const [chatRooms, setChatRooms] = useState<SelectOption[]>([])
+  const [errors, setErrors] = useState<string[]>([])
+  const apiClient = useApiClient()
+
+  useEffect(() => {
+    getChatRoomList()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const getChatRoomList = async () => {
+    try {
+      setErrors([])
+      const res = await apiClient.get('/chat_rooms')
+      setChatRooms(res.data)
+    } catch {
+      setErrors(["チャットルームを表示できませんでした。"])
+    }
+  }
+
+  const deleteChatRoom = async () => {
+    console.log("チーム紹介削除は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  }
+
+  const editChatRoom = () => {
+    console.log("チャットルーム画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  }
+
+  return (
+    <div className="flex items-center justify-center mt-32 md:mt-20">
+      <div className="w-full md:w-3/5 xl:w-2/5 pb-7 shadow-gray-200 bg-sky-100 rounded-lg">
+        <h2 className="text-center mb-7 pt-10 font-bold text-3xl text-blue-600">チャットルーム一覧</h2>
+        <div className="flex flex-col items-center">
+          {errors.length > 0 && (
+            <div className="text-red-500 text-sm my-4">
+              {errors.map((err, index) => ( <div key={index}>{err}</div> ))}
+            </div>
+          )}
+
+          {chatRooms.map((chatRoom) => (
+            <div 
+              key={chatRoom.id} 
+              className="text-left my-3 sm:ml-4 sm:mr-6 w-72 pt-3 ring-offset-2 ring-2 rounded-lg break-words"
+            >
+              チャット名: {chatRoom.name}
+              <div className="flex justify-center mt-5">
+                {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
+                <button className="update_button" onClick={() => editChatRoom()}>連絡</button>
+                <button className="delete_button mx-5" onClick={() => deleteChatRoom()}>削除</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -12,6 +12,7 @@ import HomePage from "@/pages/HomePage"
 import EventSettingPage from "@/pages/eventPages/EventSettingPage"
 import EventSettingListPage from "@/pages/eventPages/EventSettingListPage"
 import TeamProfileListPage from "@/pages/teamPages/TeamProfileListPage"
+import ChatRoomListPage from "@/pages/chatPage/ChatRoomListPage"
 
 function OpenLayout() {
   return (
@@ -63,6 +64,7 @@ export default function AppRouter() {
           <Route path="/event_setting" element={<EventSettingPage />} />
           <Route path="/event_setting_list" element={<EventSettingListPage />} />
           <Route path="/team_profile_list" element={<TeamProfileListPage />} />
+          <Route path="/chat_room_list" element={<ChatRoomListPage />} />
         </Route>
       </Route>
     </Routes>


### PR DESCRIPTION
## 変更内容
- `ChatRoomListPage.tsx` を新規作成
## 備考
- 「連絡」ボタンからイベント編集画面への遷移は他のissueにて修正予定です。
- 「連絡」「削除」ボタンは下のprをマージ次第修正予定です。
  - [イベント設定ページに開始・終了日付、募集チーム数、目的・その他入力欄を追加 ](https://github.com/toshinori-m/stay_connect/pull/199)

close https://github.com/toshinori-m/stay_connect/issues/203