### PR TITLE
イベント編集ページに基本情報（競技名、都道府県、対象年齢、イベント名、URL、開催場所、性別）を表示

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -43,11 +43,11 @@ body {
 
     /* Yellow button */
   .btn-yellow {
-    @apply text-white bg-yellow-700
+    @apply text-black bg-yellow-400
            shadow-[inset_2px_2px_3px_rgba(255,255,255,0.6),inset_-2px_-2px_3px_rgba(0,0,0,0.6)];
   }
   .btn-yellow:hover {
-    @apply bg-yellow-500;
+    @apply bg-yellow-200;
   }
   .btn-yellow:active {
     @apply shadow-[inset_-2px_-2px_3px_rgba(255,255,255,0.6),inset_2px_2px_3px_rgba(0,0,0,0.6)];

--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -19,7 +19,7 @@ interface RecruitmentData {
 }
 
 export default function EventSettingForm() {
-  const { id: recruitmentId } = useParams<{ id: string }>()
+  const { id: recruitmentId = null } = useParams<{ id?: string }>()
   const apiClient = useApiClient()
 
   const [formState, setFormState] = useState({
@@ -34,7 +34,7 @@ export default function EventSettingForm() {
   })
 
   const [errors, setErrors] = useState<string[]>([])
-  const [hasFetched, setHasFetched] = useState(false)
+  const [fetchedId, setFetchedId] = useState<string | null>(null)
 
   const {
     sportsTypes,
@@ -46,8 +46,9 @@ export default function EventSettingForm() {
   const { sportsDisciplines, errors: sportsDisciplineErrors } = useFetchDisciplines(formState.sportsTypeSelected)
 
   useEffect(() => {
-    if (hasFetched) return
-    if (!recruitmentId || sportsTypes.length === 0 || prefectures.length === 0 || targetAges.length === 0) return
+    if (fetchedId === recruitmentId) return
+    if (sportsTypes.length === 0 || prefectures.length === 0 || targetAges.length === 0) return
+
     fetchAndInitializeForm()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recruitmentId, sportsTypes, prefectures, targetAges])
@@ -62,7 +63,7 @@ export default function EventSettingForm() {
     await setSelectedSportsType(recruitmentData.sports_type_id)
     await setSelectedTargetAge(targetAgeIds)
 
-    setHasFetched(true)
+    setFetchedId(recruitmentId ?? null)
   }
 
   const fetchRecruitmentData = async () => {

--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -48,25 +48,26 @@ export default function EventSettingForm() {
   useEffect(() => {
     if (fetchedId === recruitmentId) return
     if (sportsTypes.length === 0 || prefectures.length === 0 || targetAges.length === 0) return
+    if (!recruitmentId) return
 
-    fetchAndInitializeForm()
+    fetchRecruitmentData(recruitmentId)
+    .then(recruitmentFormData => {
+      if (!recruitmentFormData) return
+      
+      const { recruitmentData, targetAgeIds } = recruitmentFormData
+  
+      setRecruitmentFormState(recruitmentData)
+      setSelectedSportsType(recruitmentData.sports_type_id)
+      setSelectedTargetAge(targetAgeIds)
+      setFetchedId(recruitmentId)
+    })
+    .catch(() => {
+      setErrors(["イベントを表示できませんでした。"])
+    })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recruitmentId, sportsTypes, prefectures, targetAges])
 
-  const fetchAndInitializeForm = async () => {
-    const recruitmentFormData = await fetchRecruitmentData()
-
-    if (!recruitmentFormData) return
-    const { recruitmentData, targetAgeIds } = recruitmentFormData
-
-    setRecruitmentFormState(recruitmentData)
-    setSelectedSportsType(recruitmentData.sports_type_id)
-    setSelectedTargetAge(targetAgeIds)
-
-    setFetchedId(recruitmentId ?? null)
-  }
-
-  const fetchRecruitmentData = async () => {
+  const fetchRecruitmentData = async (recruitmentId: string) => {
     if (!recruitmentId) return null
 
     try {

--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -53,6 +53,7 @@ export default function EventSettingForm() {
     fetchRecruitmentData(recruitmentId)
     .then(recruitmentFormData => {
       if (!recruitmentFormData) return
+      setErrors([])
       
       const { recruitmentData, targetAgeIds } = recruitmentFormData
   
@@ -68,8 +69,6 @@ export default function EventSettingForm() {
   }, [recruitmentId, sportsTypes, prefectures, targetAges])
 
   const fetchRecruitmentData = async (recruitmentId: string) => {
-    if (!recruitmentId) return null
-
     try {
       const recruitmentData = (await apiClient.get(`/recruitments/${recruitmentId}`)).data.data
       const targetAgeIds = (await apiClient.get(`/recruitments/${recruitmentId}/target_ages`)).data.map(
@@ -83,7 +82,7 @@ export default function EventSettingForm() {
     }
   }
 
-  const setRecruitmentFormState = async (recruitmentData: RecruitmentData,) => {
+  const setRecruitmentFormState = (recruitmentData: RecruitmentData,) => {
     setFormState(prev => ({
       ...prev,
       eventName: recruitmentData.name || "",
@@ -92,6 +91,32 @@ export default function EventSettingForm() {
       eventUrl: recruitmentData.event_url || "",
       prefectureSelected: recruitmentData.prefecture_id ? recruitmentData.prefecture_id.toString() : null
     }))
+  }  
+
+  const setSelectedSportsType = (selectSportsTypeId?: number) => {
+    if (selectSportsTypeId) {
+      const selectedSportsType = sportsTypes.find((sportsType: SelectOption) => sportsType.id === selectSportsTypeId)
+
+      if (selectedSportsType) {
+        setFormState(prev => ({
+          ...prev,
+          sportsTypeSelected: selectedSportsType
+        }))
+      }
+    }
+  }
+
+  const setSelectedTargetAge = (targetAgeIds?: number[]) => {
+    if (targetAgeIds && targetAgeIds.length > 0 && targetAges.length > 0) {
+      const selectedTargetAges = targetAges.filter((targetAge: SelectOption) => 
+        targetAgeIds.includes(targetAge.id)
+      )
+      
+      setFormState(prev => ({
+        ...prev,
+        targetAgeSelected: selectedTargetAges
+      }))
+    }
   }
 
   useEffect(() => {
@@ -120,43 +145,6 @@ export default function EventSettingForm() {
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recruitmentId, formState.sportsTypeSelected, sportsDisciplines])
-  
-
-  const setSelectedSportsType = async (selectSportsTypeId?: number) => {
-    try {
-      setErrors([])
-
-      if (selectSportsTypeId) {
-        const selectedSportsType = sportsTypes.find((st: SelectOption) => st.id === selectSportsTypeId)
-
-        if (selectedSportsType) {
-          setFormState(prev => ({
-            ...prev,
-            sportsTypeSelected: selectedSportsType
-          }))
-        }
-      }
-    } catch {
-      setErrors(["競技を表示できませんでした。"])
-    }
-  }
-
-  const setSelectedTargetAge = async (targetAgeIds?: number[]) => {
-    try {
-      if (targetAgeIds && targetAgeIds.length > 0 && targetAges.length > 0) {
-        const selectedTargetAges = targetAges.filter((age: SelectOption) => 
-          targetAgeIds.includes(age.id)
-        )
-        
-        setFormState(prev => ({
-          ...prev,
-          targetAgeSelected: selectedTargetAges
-        }))
-      }
-    } catch {
-      setErrors(["対象年齢を表示できませんでした。"])
-    }
-  }
 
   const ErrorList = (errors: string[]) => {
     if (errors.length === 0) return null

--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -95,32 +95,32 @@ export default function EventSettingForm() {
   }
 
   useEffect(() => {
-    fetchAndSetDisciplines()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sportsDisciplines])
+    if (!recruitmentId || !formState.sportsTypeSelected || sportsDisciplines.length === 0) return
 
-  const fetchAndSetDisciplines = async () => {
-    try {
-      if (!recruitmentId || !formState.sportsTypeSelected || sportsDisciplines.length === 0) return
-
-      const sportsDisciplineIds = (
-        await apiClient.get(`/recruitments/${recruitmentId}/sports_disciplines`)
-      ).data.map((item: { sports_discipline_id: number }) => item.sports_discipline_id)
-
-      if (sportsDisciplineIds.length > 0 && sportsDisciplines.length > 0) {
-        const selectedSportsDisciplines = sportsDisciplines.filter(sportsDiscipline =>
-          sportsDisciplineIds.includes(sportsDiscipline.id)
+    apiClient
+      .get(`/recruitments/${recruitmentId}/sports_disciplines`)
+      .then((sportsDisciplineResponse) => {
+        const sportsDisciplineIdList = sportsDisciplineResponse.data.map(
+          (record: { sports_discipline_id: number }) => record.sports_discipline_id
         )
 
-        setFormState(prev => ({
-          ...prev,
-          sportsDisciplineSelected: selectedSportsDisciplines
-        }))
-      }
-    } catch {
-      setErrors(["種目の取得に失敗しました。"])
-    }
-  }
+        if (sportsDisciplineIdList.length > 0 && sportsDisciplines.length > 0) {
+          const selectedSportsDisciplines = sportsDisciplines.filter(sportsDiscipline =>
+            sportsDisciplineIdList.includes(sportsDiscipline.id)
+          )
+
+          setFormState(prev => ({
+            ...prev,
+            sportsDisciplineSelected: selectedSportsDisciplines,
+          }))
+        }
+      })
+      .catch(() => {
+        setErrors(["種目の取得に失敗しました。"])
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recruitmentId, formState.sportsTypeSelected, sportsDisciplines])
+  
 
   const setSelectedSportsType = async (selectSportsTypeId?: number) => {
     try {

--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useState, useRef } from 'react'
+import { useParams } from 'react-router-dom'
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+import InputField from "@/components/ui/InputField"
+import TextareaField from "@/components/ui/TextareaField"
+import SelectField from "@/components/ui/SelectField"
+import RadioGroupField from "@/components/ui/RadioGroupField"
+import useInitialFormData from "@/hooks/search/useInitialFormData"
+import useFetchDisciplines from "@/hooks/search/useFetchDisciplines"
+
+export default function EventSettingForm() {
+  const { id } = useParams<{ id: string }>()
+  const apiClient = useApiClient()
+
+  const [formState, setFormState] = useState({
+    sportsTypeSelected: null as SelectOption | null,
+    sportsDisciplineSelected: [] as SelectOption[],
+    targetAgeSelected: [] as SelectOption[],
+    prefectureSelected: null as string | null,
+    eventName: "",
+    eventUrl: "",
+    area: "",
+    sex: ""
+  })
+
+  const {
+    sportsTypes,
+    prefectures,
+    targetAges,
+    errors: initialErrors
+  } = useInitialFormData()
+
+  const { sportsDisciplines, errors: disciplineErrors } = useFetchDisciplines(formState.sportsTypeSelected)
+  const disciplineIdsRef = useRef<number[]>([])
+  const [errors, setErrors] = useState<string[]>([])
+  const hasFetchedRef = useRef(false)
+
+  useEffect(() => {
+    if (hasFetchedRef.current) return
+    if (!id || sportsTypes.length === 0 || prefectures.length === 0 || targetAges.length === 0) return
+
+    getEventSettingData()
+    hasFetchedRef.current = true 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, sportsTypes, prefectures, targetAges])
+
+  useEffect(() => {
+    if (disciplineIdsRef.current.length > 0 && sportsDisciplines.length > 0) {
+      const selected = sportsDisciplines.filter(discipline =>
+        disciplineIdsRef.current.includes(discipline.id)
+      )
+      
+      setFormState(prev => ({
+        ...prev,
+        sportsDisciplineSelected: selected
+      }))
+    }
+  }, [sportsDisciplines])
+
+  const getEventSettingData = async () => {
+    try {
+      if (!id) return
+      setErrors([])
+
+      const res = await apiClient.get(`/recruitments/${id}`)
+      const recruitmentData = res.data.data
+
+      setFormState(prev => ({
+        ...prev,
+        eventName: recruitmentData.name || "",
+        area: recruitmentData.area || "",
+        sex: recruitmentData.sex || "",
+        eventUrl: recruitmentData.event_url || "",
+        prefectureSelected: recruitmentData.prefecture_id ? recruitmentData.prefecture_id.toString() : null
+      }))
+
+      const rdsRes = await apiClient.get(`/recruitments/${id}/sports_disciplines`)
+      disciplineIdsRef.current = rdsRes.data.map((item: { sports_discipline_id: number }) => item.sports_discipline_id)
+
+      const rtaRes = await apiClient.get(`/recruitments/${id}/target_ages`)
+      const targetAgeIds = rtaRes.data.map((item: { target_age_id: number }) => item.target_age_id)
+
+      await getSportsType(recruitmentData.sports_type_id)
+      await getTargetAge(targetAgeIds)
+    } catch {
+      setErrors(["イベントを表示できませんでした。"])
+    }
+  }
+  
+  const getSportsType = async (selectedTypeId?: number) => {
+    try {
+      setErrors([])
+
+      if (selectedTypeId) {
+        const foundSportsType = sportsTypes.find((st: SelectOption) => st.id === selectedTypeId)
+
+        if (foundSportsType) {
+          setFormState(prev => ({
+            ...prev,
+            sportsTypeSelected: foundSportsType
+          }))
+        }
+      }
+    } catch {
+      setErrors(["競技を表示できませんでした。"])
+    }
+  }
+
+  const getTargetAge = async (targetAgeIds?: number[]) => {
+    try {
+      if (targetAgeIds && targetAgeIds.length > 0 && targetAges.length > 0) {
+        const selected = targetAges.filter((age: SelectOption) => 
+          targetAgeIds.includes(age.id)
+        )
+        
+        setFormState(prev => ({
+          ...prev,
+          targetAgeSelected: selected
+        }))
+      }
+    } catch {
+      setErrors(["対象年齢を表示できませんでした。"])
+    }
+  }
+
+  const renderErrorList = (errors: string[]) => {
+    if (errors.length === 0) return null
+
+    return (
+      <div className="text-red-500 text-sm list-disc list-inside text-left md:pl-44 pl-12">
+        {errors.map((error, index) => (
+          <li key={index}>{error}</li>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-center mt-32 md:mt-20">
+      <div className="w-full md:w-3/5 xl:w-2/5 shadow-gray-200 bg-sky-100 rounded-lg">
+        <h2 className="text-center mb-10 pt-10 font-bold text-3xl text-blue-600">イベント登録</h2>
+          <ul className="space-y-4 text-left">
+            {/* 競技種別 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <SelectField
+                  name="eventSportsType"
+                  label="競技名"
+                  value={formState.sportsTypeSelected ? formState.sportsTypeSelected.id : ""}
+                  options={sportsTypes}
+                  onChange={() => {}}
+                />
+              </div>
+            </li>
+
+            {/* 種目 */}
+            {sportsDisciplines.length > 0 && (
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <SelectField
+                    name="eventSportsDiscipline"
+                    multiple
+                    label={<>種目<br />（複数可）</>}
+                    value={formState.sportsDisciplineSelected.map(d => d.id.toString())}
+                    options={sportsDisciplines}
+                    onChange={() => {}}
+                  />
+                </div>
+              </li>
+            )}
+
+            {/* 都道府県 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <SelectField
+                  name="eventPrefecture"
+                  label="都道府県"
+                  value={formState.prefectureSelected ? formState.prefectureSelected : ""}
+                  options={prefectures}
+                  onChange={() => {}}
+                />
+              </div>
+            </li>
+
+            {/* 対象年齢 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <SelectField
+                  name="eventTargetAge"
+                  multiple
+                  label={
+                    <>
+                      対象年齢
+                      <br />
+                      （複数可）
+                    </>
+                  }
+                  value={formState.targetAgeSelected.map(age => age.id.toString())}
+                  options={targetAges}
+                  onChange={() => {}}
+                />
+              </div>
+            </li>
+
+            {/* イベント名 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <InputField
+                  name="eventName"
+                  type="text"
+                  label="イベント名"
+                  placeholder="イベント名"
+                  value={formState.eventName}
+                  onChange={() => {}}
+                />
+              </div>
+            </li>
+
+            {/* イベントURL */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <InputField
+                  name="eventURL"
+                  type="url"
+                  label="イベントURL"
+                  placeholder="https://www.example.com"
+                  value={formState.eventUrl}
+                  onChange={() => {}}
+                />
+              </div>
+            </li>
+
+            {/* イベント開催場所 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <TextareaField
+                  name="eventArea"
+                  label="イベント開催場所"
+                  placeholder="イベント開催場所"
+                  value={formState.area}
+                  rows={4}
+                  onChange={() => {}}
+                />
+              </div>
+            </li>
+
+            {/* 性別 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <RadioGroupField
+                  name="eventSex"
+                  label="性別"
+                  options={[
+                    { label: "男", value: "man" },
+                    { label: "女", value: "woman" },
+                    { label: "男女", value: "mix" },
+                    { label: "混合", value: "man_and_woman" }
+                  ]}
+                  selected={formState.sex}
+                  onChange={() => {}}
+                />
+              </div>
+            </li>
+            {/* 「開始日付」「終了日付」「募集チーム数」「イベント目的」「その他」の追加及びこのページの編集・送信機能は次回PRで対応予定 */}
+          </ul>
+          {renderErrorList([...initialErrors, ...disciplineErrors, ...errors])}
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -59,9 +59,9 @@ export default function EventSettingForm() {
     if (!recruitmentFormData) return
     const { recruitmentData, targetAgeIds } = recruitmentFormData
 
-    await setRecruitmentFormState(recruitmentData)
-    await setSelectedSportsType(recruitmentData.sports_type_id)
-    await setSelectedTargetAge(targetAgeIds)
+    setRecruitmentFormState(recruitmentData)
+    setSelectedSportsType(recruitmentData.sports_type_id)
+    setSelectedTargetAge(targetAgeIds)
 
     setFetchedId(recruitmentId ?? null)
   }

--- a/frontend-react/src/pages/eventPages/EventSettingListPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingListPage.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useApiClient } from "@/hooks/useApiClient"
 import { SelectOption } from "@/types"
+import Button from "@/components/ui/Button"
 
 export default function EventList() {
   const [recruitments, setRecruitments] = useState<SelectOption[]>([])
   const [errors, setErrors] = useState<string[]>([])
   const apiClient = useApiClient()
+  const navigate = useNavigate()
 
   useEffect(() => {
     getRecruitment()
@@ -22,8 +25,8 @@ export default function EventList() {
     }
   }
 
-  const editRecruitment = () => {
-    console.log("イベント編集画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  const editRecruitment = (id: number) => {
+    navigate(`/event_setting_edit/${id}`)
   }
 
   const deleteRecruitment = async (id: number) => {
@@ -54,9 +57,8 @@ export default function EventList() {
             >
               イベント名: {recruitment.name}
               <div className="flex justify-center mt-5">
-                {/* TODO: ボタンのデザインについては後続タスクで処理を追加 */}
-                <button className="update_button" onClick={() => editRecruitment()}>更新</button>
-                <button className="delete_button mx-5" onClick={() => deleteRecruitment(recruitment.id)}>削除</button>
+                <Button variant="yellow" size="sm" className="my-4 md:mb-0 md:mr-4 mx-3" onClick={() => editRecruitment(recruitment.id)}>編集</Button>
+                <Button variant="red" size="sm" className="my-4 md:mb-0 md:mr-4 mx-3" onClick={() => deleteRecruitment(recruitment.id)}>削除</Button>
               </div>
             </div>
           ))}

--- a/frontend-react/src/pages/eventPages/EventSettingPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingPage.tsx
@@ -165,7 +165,7 @@ export default function EventSettingPage() {
     { errors: [], formData: null }
   )
   
-  const renderErrorList = (errors: string[]) => {
+  const ErrorList = (errors: string[]) => {
     if (errors.length === 0) return null
   
     return (
@@ -395,7 +395,7 @@ export default function EventSettingPage() {
               </div>
             </li>
           </ul>
-          {renderErrorList([...initialErrors, ...disciplineErrors, ...actionState.errors])}
+          {ErrorList([...initialErrors, ...disciplineErrors, ...actionState.errors])}
           {/* 登録ボタン */}
           <div className="text-center mb-5">
             <Button variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4">登録する</Button>

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -13,6 +13,7 @@ import EventSettingPage from "@/pages/eventPages/EventSettingPage"
 import EventSettingListPage from "@/pages/eventPages/EventSettingListPage"
 import TeamProfileListPage from "@/pages/teamPages/TeamProfileListPage"
 import ChatRoomListPage from "@/pages/chatPage/ChatRoomListPage"
+import EventSettingEditPage from "@/pages/eventPages/EventSettingEditPage"
 
 function OpenLayout() {
   return (
@@ -65,6 +66,7 @@ export default function AppRouter() {
           <Route path="/event_setting_list" element={<EventSettingListPage />} />
           <Route path="/team_profile_list" element={<TeamProfileListPage />} />
           <Route path="/chat_room_list" element={<ChatRoomListPage />} />
+          <Route path="/event_setting_edit/:id" element={<EventSettingEditPage />} />
         </Route>
       </Route>
     </Routes>


### PR DESCRIPTION
## 概要
- イベント編集ページ（EventSettingEditPage.tsx）を新規作成
- 下の項目をAPIから取得してフォームに表示する機能を実装（表示のみ、編集・送信は未対応）

## 表示項目
- 競技名（sportsType）
- 都道府県（prefecture）
- 対象年齢（targetAge）
- イベント名
- イベントURL
- 開催場所（area）
- 性別（sex）

## 備考
- 下の項目の追加及びこのページの編集・送信機能は次回PRで対応予定
  - 「開始日付」「終了日付」「募集チーム数」「イベント目的」「その他」

close https://github.com/toshinori-m/stay_connect/issues/191