### PR TITLE
各ページのボタンを共通のButtonコンポーネントに置き換え、コードの一貫性を向上

### DIFF
--- a/frontend-react/src/components/layout/OpenHeader.tsx
+++ b/frontend-react/src/components/layout/OpenHeader.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom"
 import MouseCharacter from "@/components/layout/MouseCharacter"
+import Button from "@/components/ui/Button"
 
 export default function OpenHeader() {
   const navigate = useNavigate()
@@ -22,12 +23,12 @@ export default function OpenHeader() {
       </div>
 
       <div className="flex flex-col mt-3 md:-mt-10 md:flex-row justify-center md:justify-end items-center">
-        <button className="btn-ok mb-2 md:mb-0 md:mr-4" onClick={redirectToSignup}>
+        <Button type="submit" variant="primary" size="sm" className="md:mb-0 md:mr-4" onClick={redirectToSignup}>
           無料登録
-        </button>
-        <button className="btn-login" onClick={redirectToLogin}>
+        </Button>
+        <Button type="submit" variant="ghost" size="sm" className="mt-3 md:mt-0 md:mb-0 md:mr-4" onClick={redirectToLogin}>
           ログイン
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/frontend-react/src/pages/LoginPage.tsx
+++ b/frontend-react/src/pages/LoginPage.tsx
@@ -7,6 +7,7 @@ import { signInWithEmailAndPassword, GoogleAuthProvider, signInWithPopup } from 
 import { useSetAuth } from "@/context/useAuthContext"
 import { useApiClient } from "@/hooks/useApiClient"
 import { AxiosError } from "axios"
+import Button from "@/components/ui/Button"
 
 export default function LoginPage() {
   const [errors, setErrors] = useState<string[]>([])
@@ -127,7 +128,7 @@ export default function LoginPage() {
                 ))}
               </div>
             )}
-            <button className="btn-ok my-4 md:mb-0 md:mr-4">ログイン</button>
+            <Button type="submit" variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4">ログイン</Button>
           </form>
           <div className="flex flex-col items-center my-7 text-blue-600">
             <CustomButton onClick={signInWithGoogle} icon="i-lucide-mail">

--- a/frontend-react/src/pages/OpenPage.tsx
+++ b/frontend-react/src/pages/OpenPage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom"
+import Button from "@/components/ui/Button"
 
 export default function OpenPage() {
   const navigate = useNavigate()
@@ -21,9 +22,9 @@ export default function OpenPage() {
               <li>チームの繋がり：開催者へ連絡出来る</li>
             </ul>
             <div className="mt-60 md:-px-16 md:text-left md:mt-20">
-              <button className="btn-signup" onClick={redirectToSignup}>
+              <Button type="submit" variant="primary" size="lg" className="btn-signup" onClick={redirectToSignup}>
                 会員登録（無料）
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/frontend-react/src/pages/RegisterPage.tsx
+++ b/frontend-react/src/pages/RegisterPage.tsx
@@ -5,6 +5,7 @@ import { createUserWithEmailAndPassword } from "firebase/auth"
 import { useApiClient } from "@/hooks/useApiClient"
 import { useSetAuth } from "@/context/useAuthContext"
 import { useNavigate } from "react-router-dom"
+import Button from "@/components/ui/Button"
 
 export default function RegisterPage() {
   const [name, setName] = useState("")
@@ -141,7 +142,7 @@ export default function RegisterPage() {
                   ))}
                 </div>
               )}
-            <button className="btn-ok my-4 md:mb-0 md:mr-4">登録する</button>
+            <Button type="submit" variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4">登録する</Button>
           </form>
         </div>
         <button onClick={handleLoginClick} className="block mx-auto w-80 my-7 text-blue-600 border-4 border-violet-400 border-dashed outline-dashed px-0 py-2">

--- a/frontend-react/src/pages/SendEmailPage.tsx
+++ b/frontend-react/src/pages/SendEmailPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { getAuth, sendPasswordResetEmail } from "firebase/auth"
 import InputField from "@/components/ui/InputField"
+import Button from "@/components/ui/Button"
 
 export default function ResetPassword() {
   const [email, setEmail] = useState("")
@@ -55,7 +56,7 @@ export default function ResetPassword() {
                 ))}
               </div>
             )}
-            <button className="btn-ok my-4 md:mb-0 md:mr-4">送信する</button>
+            <Button type="submit" variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4">送信する</Button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
## 概要
複数ページで使用されているボタンを共通化するため、以下のファイルで適用しました。

### 修正対象ファイル
- OpenHeader.tsx
- LoginPage.tsx
- RegisterPage.tsx
- SendEmailPage.tsx
- OpenPage.tsx

## 目的
- デザインの統一
- コンポーネント再利用による保守性向上

close https://github.com/toshinori-m/stay_connect/issues/206