### PR TITLE
イベント編集ページに開始日付・終了日付・募集チーム数・目的・その他の入力項目と編集・送信・削除機能を追加

### DIFF
--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -8,6 +8,9 @@ import SelectField from "@/components/ui/SelectField"
 import RadioGroupField from "@/components/ui/RadioGroupField"
 import useInitialFormData from "@/hooks/search/useInitialFormData"
 import useFetchDisciplines from "@/hooks/search/useFetchDisciplines"
+import { useActionState } from "react"
+import { useNavigate } from "react-router-dom"
+import Button from "@/components/ui/Button"
 
 interface RecruitmentData {
   name: string
@@ -16,11 +19,17 @@ interface RecruitmentData {
   event_url: string
   prefecture_id: number
   sports_type_id: number
+  start_date: string
+  end_date: string
+  number: string
+  purpose_body: string
+  other_body: string
 }
 
 export default function EventSettingForm() {
   const { id: recruitmentId = null } = useParams<{ id?: string }>()
   const apiClient = useApiClient()
+  const navigate = useNavigate()
 
   const [formState, setFormState] = useState({
     sportsTypeSelected: null as SelectOption | null,
@@ -30,7 +39,12 @@ export default function EventSettingForm() {
     eventName: "",
     eventUrl: "",
     area: "",
-    sex: ""
+    sex: "",
+    startDate: "2023-01-01",
+    endDate: "2023-01-01",
+    eventNumber: "",
+    purposeBody: "",
+    otherBody: ""
   })
 
   const [errors, setErrors] = useState<string[]>([])
@@ -89,7 +103,12 @@ export default function EventSettingForm() {
       area: recruitmentData.area || "",
       sex: recruitmentData.sex || "",
       eventUrl: recruitmentData.event_url || "",
-      prefectureSelected: recruitmentData.prefecture_id ? recruitmentData.prefecture_id.toString() : null
+      prefectureSelected: recruitmentData.prefecture_id ? recruitmentData.prefecture_id.toString() : null,
+      startDate: recruitmentData.start_date || "2023-01-01",
+      endDate: recruitmentData.end_date || "2023-01-01",
+      eventNumber: recruitmentData.number || "",
+      purposeBody: recruitmentData.purpose_body || "",
+      otherBody: recruitmentData.other_body || ""
     }))
   }  
 
@@ -146,6 +165,144 @@ export default function EventSettingForm() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recruitmentId, formState.sportsTypeSelected, sportsDisciplines])
 
+  const SHOW_LIMIT_THRESHOLD = 5
+  const MAX_LENGTH = 255
+  const remainingCharacters = (input: string) => MAX_LENGTH - input.length
+
+  const formatSelectedNames = (selectedOptions: SelectOption[]) => {
+    if (selectedOptions.length === 0) return null
+  
+    return (
+      <div className="mt-2 py-2 px-3 md:mx-8 border-2 border-gray-200 rounded-lg bg-white text-gray-700">
+        {selectedOptions.map((selectedOption) => selectedOption.name).join(", ")}
+      </div>
+    )
+  }
+
+  const updateFormState = (field: string, value: unknown) => {
+    setFormState(prev => ({ ...prev, [field]: value }))
+  }
+
+  const handleSportsTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = sportsTypes.find(s => s.id.toString() === e.target.value) || null
+    updateFormState('sportsTypeSelected', selected)
+    updateFormState('sportsDisciplineSelected', [])
+  }
+
+  const handleMultiSelectChange = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+    options: SelectOption[],
+    field: string
+  ) => {
+    const selectedIds = Array.from(e.target.selectedOptions).map(opt => opt.value)
+    const selectedOptions = options.filter(opt => selectedIds.includes(opt.id.toString()))
+    updateFormState(field, selectedOptions)
+  }
+
+  const handlePrefectureChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    updateFormState('prefectureSelected', e.target.value)
+  }
+
+  const handleInputChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    updateFormState(field, e.target.value)
+  }
+  
+  const handleSexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateFormState('sex', e.target.value)
+  }
+
+  const [actionState, action] = useActionState(
+    async (_prevState:  { errors: string[] }, formData: FormData) => {
+      const newErrors: string[] = []
+      const currentFormState = { ...formState }
+      
+      // FormDataから値を取得
+      const eventName = formData.get('eventName') as string
+      const eventUrl = formData.get('eventURL') as string
+      const area = formData.get('eventArea') as string
+      const sex = formData.get('eventSex') as string
+      const startDate = formData.get('eventStartDate') as string
+      const endDate = formData.get('eventEndDate') as string
+      const number = formData.get('eventNumber') as string
+      const purposeBody = formData.get('eventPurposeBody') as string
+      const otherBody = formData.get('eventOtherBody') as string
+
+      // 選択項目は状態から取得
+      const sportsTypeSelected = formState.sportsTypeSelected
+      const disciplineIds = formState.sportsDisciplineSelected.map(d => d.id)
+      const targetAgeIds = formState.targetAgeSelected.map(t => t.id)
+      const prefectureSelected = formState.prefectureSelected
+
+      // バリデーション
+      if (!sportsTypeSelected) newErrors.push("競技名を選択してください。")
+      if (sportsDisciplines.length > 0 && disciplineIds.length === 0) newErrors.push("種目名を選択してください。")
+      if (!prefectureSelected) newErrors.push("都道府県を選択してください。")
+      if (targetAgeIds.length === 0) newErrors.push("対象年齢を選択してください。")
+      if (!eventName.trim()) newErrors.push("イベント名を入力してください。")
+      if (!area.trim()) newErrors.push("イベント開催場所を入力してください。")
+      if (!sex.trim()) newErrors.push("性別を選択してください。")
+      if (!number.trim()) newErrors.push("募集チーム数を入力してください。")
+      if (!purposeBody.trim()) newErrors.push("イベント目的を入力してください。")
+
+      const today = new Date()
+      today.setHours(0, 0, 0, 0)
+      const selectedStartDate = new Date(startDate)
+      const selectedEndDate = new Date(endDate)
+
+      if (selectedStartDate < today) newErrors.push("開始日は今日以降の日付を選択してください。")
+      if (selectedEndDate < today) newErrors.push("今日以降の終了日付を選択してください。")
+
+      if (newErrors.length > 0) {
+        return { errors: newErrors, formData: currentFormState }
+      }
+
+      try {
+        await apiClient.patch(`/recruitments/${recruitmentId}`, {
+          recruitment: {
+            image: eventUrl,
+            name: eventName,
+            area,
+            sex,
+            number,
+            start_date: startDate,
+            end_date: endDate,
+            purpose_body: purposeBody,
+            other_body: otherBody,
+            sports_type_id: sportsTypeSelected?.id,
+            sports_discipline_ids: disciplineIds,
+            prefecture_id: prefectureSelected,
+            target_age_ids: targetAgeIds,
+          }
+        })
+        navigate("/event_setting_list")
+        return { errors: [], formData: null }
+      } catch {
+        return {
+          errors: ["イベント更新に失敗しました。入力を確認してください。"],
+          formData: currentFormState
+        }
+      }
+    },
+    { errors: [], formData: null }
+  )
+
+  useEffect(() => {
+    if (actionState.formData) {
+      setFormState(actionState.formData)
+    }
+  }, [actionState.formData])
+
+  const recruitmentHandleDelete = async () => {
+    if (!recruitmentId) return
+    
+    try {
+      await apiClient.delete(`/recruitments/${recruitmentId}`)
+      navigate('/event_setting_list')
+    } catch {
+      setErrors(["イベントを削除できませんでした。"])
+    }
+  }
+
   const ErrorList = (errors: string[]) => {
     if (errors.length === 0) return null
 
@@ -161,7 +318,8 @@ export default function EventSettingForm() {
   return (
     <div className="flex items-center justify-center mt-32 md:mt-20">
       <div className="w-full md:w-3/5 xl:w-2/5 shadow-gray-200 bg-sky-100 rounded-lg">
-        <h2 className="text-center mb-10 pt-10 font-bold text-3xl text-blue-600">イベント登録</h2>
+        <h2 className="text-center mb-10 pt-10 font-bold text-3xl text-blue-600">イベント編集</h2>
+        <form className="px-4 md:px-0 text-center" action={action}>
           <ul className="space-y-4 text-left">
             {/* 競技種別 */}
             <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
@@ -171,8 +329,7 @@ export default function EventSettingForm() {
                   label="競技名"
                   value={formState.sportsTypeSelected ? formState.sportsTypeSelected.id : ""}
                   options={sportsTypes}
-                  // TODO: 後続PRで実装する編集・送信機能追加時に実装する
-                  onChange={() => {}}
+                  onChange={handleSportsTypeChange}
                 />
               </div>
             </li>
@@ -187,9 +344,9 @@ export default function EventSettingForm() {
                     label={<>種目<br />（複数可）</>}
                     value={formState.sportsDisciplineSelected.map(d => d.id.toString())}
                     options={sportsDisciplines}
-                    // TODO: 後続PRで実装する編集・送信機能追加時に実装する
-                    onChange={() => {}}
+                    onChange={(e) => handleMultiSelectChange(e, sportsDisciplines, 'sportsDisciplineSelected')}
                   />
+                  {formatSelectedNames(formState.sportsDisciplineSelected)}
                 </div>
               </li>
             )}
@@ -202,8 +359,7 @@ export default function EventSettingForm() {
                   label="都道府県"
                   value={formState.prefectureSelected ? formState.prefectureSelected : ""}
                   options={prefectures}
-                  // TODO: 後続PRで実装する編集・送信機能追加時に実装する
-                  onChange={() => {}}
+                  onChange={handlePrefectureChange}
                 />
               </div>
             </li>
@@ -214,18 +370,12 @@ export default function EventSettingForm() {
                 <SelectField
                   name="eventTargetAge"
                   multiple
-                  label={
-                    <>
-                      対象年齢
-                      <br />
-                      （複数可）
-                    </>
-                  }
+                  label={<>対象年齢<br />（複数可）</>}
                   value={formState.targetAgeSelected.map(age => age.id.toString())}
                   options={targetAges}
-                  // TODO: 後続PRで実装する編集・送信機能追加時に実装する
-                  onChange={() => {}}
+                  onChange={(e) => handleMultiSelectChange(e, targetAges, 'targetAgeSelected')}
                 />
+                {formatSelectedNames(formState.targetAgeSelected)}
               </div>
             </li>
 
@@ -238,9 +388,11 @@ export default function EventSettingForm() {
                   label="イベント名"
                   placeholder="イベント名"
                   value={formState.eventName}
-                  // TODO: 後続PRで実装する編集・送信機能追加時に実装する
-                  onChange={() => {}}
+                  onChange={handleInputChange('eventName')}
                 />
+                {remainingCharacters(formState.eventName) <= SHOW_LIMIT_THRESHOLD && (
+                  <div className="text-red-500 text-sm">イベント名はあと{remainingCharacters(formState.eventName)}文字までです。</div>
+                )}
               </div>
             </li>
 
@@ -253,8 +405,7 @@ export default function EventSettingForm() {
                   label="イベントURL"
                   placeholder="https://www.example.com"
                   value={formState.eventUrl}
-                  // TODO: 後続PRで実装する編集・送信機能追加時に実装する
-                  onChange={() => {}}
+                  onChange={handleInputChange('eventUrl')}
                 />
               </div>
             </li>
@@ -268,8 +419,7 @@ export default function EventSettingForm() {
                   placeholder="イベント開催場所"
                   value={formState.area}
                   rows={4}
-                  // TODO: 後続PRで実装する編集・送信機能追加時に実装する
-                  onChange={() => {}}
+                  onChange={handleInputChange('area')}
                 />
               </div>
             </li>
@@ -287,14 +437,87 @@ export default function EventSettingForm() {
                     { label: "混合", value: "man_and_woman" }
                   ]}
                   selected={formState.sex}
-                  // TODO: 後続PRで実装する編集・送信機能追加時に実装する
-                  onChange={() => {}}
+                  onChange={handleSexChange}
                 />
               </div>
             </li>
-            {/* 「開始日付」「終了日付」「募集チーム数」「イベント目的」「その他」の追加及びこのページの編集・送信機能は次回PRで対応予定 */}
+            
+            {/* 開始日付 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <InputField
+                  name="eventStartDate"
+                  type="date"
+                  label="開始日付"
+                  value={formState.startDate}
+                  onChange={handleInputChange('startDate')}
+                  min={new Date().toISOString().split("T")[0]}
+                />
+              </div>
+            </li>
+            
+            {/* 終了日付 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <InputField
+                  name="eventEndDate"
+                  type="date"
+                  label="終了日付"
+                  value={formState.endDate}
+                  onChange={handleInputChange('endDate')}
+                />
+              </div>
+            </li>
+
+            {/* 募集チーム数 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <InputField
+                  name="eventNumber"
+                  type="number"
+                  label="募集チーム数"
+                  placeholder="募集チーム数"
+                  value={formState.eventNumber}
+                  onChange={handleInputChange('eventNumber')}
+                />
+              </div>
+            </li>
+
+            {/* イベント目的 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <TextareaField
+                  name="eventPurposeBody"
+                  label="イベント目的"
+                  placeholder="イベント目的"
+                  value={formState.purposeBody}
+                  onChange={handleInputChange('purposeBody')}
+                  rows={5}
+                />
+              </div>
+            </li>
+
+            {/* その他 */}
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <TextareaField
+                  name="eventOtherBody"
+                  label="その他"
+                  placeholder="その他"
+                  value={formState.otherBody}
+                  onChange={handleInputChange('otherBody')}
+                  rows={5}
+                />
+              </div>
+            </li>
           </ul>
-          {ErrorList([...initialErrors, ...sportsDisciplineErrors, ...errors])}
+          {ErrorList([...initialErrors, ...sportsDisciplineErrors, ...errors, ...actionState.errors])}
+          {/* 登録ボタン */}
+          <div className="text-center my-5">
+            <Button type="submit" variant="primary" size="sm" className="mr-4">更新</Button>
+            <Button type="submit" variant="red" size="sm" onClick={recruitmentHandleDelete}>削除</Button>
+          </div>
+        </form>
       </div>
     </div>
   )


### PR DESCRIPTION
### 概要
- イベント編集ページ（EventSettingEditPage.tsx）に以下の機能を追加しました。

### 変更内容
- 開始日付、終了日付、募集チーム数、イベント目的、その他の入力項目をフォームに追加
- フォーム送信による更新処理を実装（useActionStateを利用、更新後はイベント一覧ページへ遷移）
- 登録済みイベントの削除機能を追加（削除後はイベント一覧ページへ遷移）

### 動作確認
- バリデーションエラー表示の確認

close https://github.com/toshinori-m/stay_connect/issues/211