### PR TITLE
チーム作成画面（TeamProfilePage）を新規追加

### DIFF
--- a/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { SelectOption } from "@/types"
 import { useApiClient } from "@/hooks/useApiClient"
 import Button from "@/components/ui/Button"
@@ -8,13 +9,14 @@ export default function TeamProfileList() {
   const [errors, setErrors] = useState<string[]>([])
   const MAX_TEAM_NUMBER = 5
   const apiClient = useApiClient()
+  const navigate = useNavigate()
 
   useEffect(() => {
-    getTeamProfile()
+    fetchTeamProfile()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const getTeamProfile = async () => {
+  const fetchTeamProfile = async () => {
     try {
       setErrors([])
       const res = await apiClient.get('/teams')
@@ -33,7 +35,7 @@ export default function TeamProfileList() {
   }
 
   const createTeamProfile = () => {
-    console.log("チーム紹介作成画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+    navigate("/team_profile")
   }
 
   return (
@@ -50,7 +52,7 @@ export default function TeamProfileList() {
           >
             チーム紹介作成
             <br />
-            （最大5チームまで）
+            （最大{MAX_TEAM_NUMBER}チームまで）
           </Button>
         </div>
         <div className="flex flex-col items-center">
@@ -62,13 +64,13 @@ export default function TeamProfileList() {
           <div className="flex flex-col items-center mt-10 mb-10">
             {teams.map((team) => (
               <div
+                className="text-left my-3 sm:ml-4 sm:mr-6 w-72 p-4 ring-offset-2 ring-2 rounded-lg break-words"
                 key={team.id}
-                className="text-left my-3 sm:ml-4 sm:mr-6 w-72 pt-3 ring-offset-2 ring-2 rounded-lg break-words"
               >
                 チーム名: {team.name}
-                <div className="flex justify-center">
-                  <Button variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4" onClick={() => editTeamProfile()}>修正</Button>
-                  <Button variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4" onClick={() => deleteTeamProfile()}>削除</Button>
+                <div className="flex justify-center mt-5">
+                  <Button variant="yellow" size="sm" className="my-4 md:mb-0 md:mr-4 mx-3" onClick={() => editTeamProfile()}>編集</Button>
+                  <Button variant="red" size="sm" className="my-4 md:mb-0 md:mr-4 mx-3" onClick={() => deleteTeamProfile()}>削除</Button>
                 </div>
               </div>
             ))}

--- a/frontend-react/src/pages/teamPages/TeamProfilePage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfilePage.tsx
@@ -1,0 +1,326 @@
+import { SelectOption } from "@/types"
+import { useEffect, useState, useActionState } from "react"
+import { useNavigate } from "react-router-dom"
+import { useApiClient } from "@/hooks/useApiClient"
+import SelectField from "@/components/ui/SelectField"
+import InputField from "@/components/ui/InputField"
+import TextareaField from "@/components/ui/TextareaField"
+import RadioGroupField from "@/components/ui/RadioGroupField"
+import Button from "@/components/ui/Button"
+import useInitialFormData from "@/hooks/search/useInitialFormData"
+import useFetchDisciplines from "@/hooks/search/useFetchDisciplines"
+
+export default function TeamProfilePage() {
+  const apiClient = useApiClient()
+  const navigate = useNavigate()
+
+  const [formState, setFormState] = useState({
+    sportsTypeSelected: null as SelectOption | null,
+    sportsDisciplineSelected: [] as SelectOption[],
+    targetAgeSelected: [] as SelectOption[],
+    prefectureSelected: null as string | null,
+    teamName: "",
+    area: "",
+    sex: "",
+    trackRecord: "",
+    otherBody: "",
+  })
+
+  const {
+    sportsTypes,
+    prefectures,
+    targetAges,
+    errors: initialErrors,
+  } = useInitialFormData()
+
+  const { sportsDisciplines, errors: disciplineErrors } = useFetchDisciplines(formState.sportsTypeSelected)
+
+  const SHOW_LIMIT_THRESHOLD = 5
+  const MAX_LENGTH = 255
+  const remainingCharactersTeamName = MAX_LENGTH - formState.teamName.length
+  const remainingCharactersArea = MAX_LENGTH - formState.area.length
+  const remainingCharactersTrackRecord = MAX_LENGTH - formState.trackRecord.length
+
+  const TEAM_FIELDS = {
+    SPORTS_TYPE: "teamSportsType",
+    SPORTS_DISCIPLINE: "teamSportsDiscipline",
+    PREFECTURE: "teamPrefecture",
+    NAME: "teamName",
+    AREA: "area",
+    SEX: "teamSex",
+    TARGET_AGE: "teamTargetAge",
+    TARGET_RECORD: "trackRecord",
+    OTHER_BODY: "otherBody"
+  }
+
+  const updateFormState = (field: string, value: unknown) => {
+    setFormState(prev => ({ ...prev, [field]: value }))
+  }
+
+  const handleSportsTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = sportsTypes.find(sportsType => sportsType.id.toString() === e.target.value) || null
+    updateFormState("sportsTypeSelected", selected)
+    updateFormState("sportsDisciplineSelected", [])
+  }
+
+  const handleMultiSelectChange = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+    options: SelectOption[],
+    field: string
+  ) => {
+    const selectedIds = Array.from(e.target.selectedOptions).map(selectedOption => selectedOption.value)
+    const selectedOptions = options.filter(option => selectedIds.includes(option.id.toString()))
+    updateFormState(field, selectedOptions)
+  }
+
+
+  const handlePrefectureChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    updateFormState("prefectureSelected", e.target.value)
+  }
+
+  const handleInputChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    updateFormState(field, e.target.value)
+  }
+
+  const handleSexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateFormState("sex", e.target.value)
+  }
+
+  const formatSelectedNames = (selected: SelectOption[]) => {
+    if (selected.length === 0) return null
+  
+    return (
+      <div className="mt-2 py-2 px-3 border-2 border-gray-200 rounded-lg bg-white text-gray-700">
+        {selected.map((s) => s.name).join(", ")}
+      </div>
+    )
+  }
+
+  const [actionState, action] = useActionState(
+    async () => {
+      const newErrors = []
+      const currentFormState = { ...formState }
+      
+      if (!formState.sportsTypeSelected) {newErrors.push("競技を選択して下さい")}
+      if (!formState.prefectureSelected) {newErrors.push("都道府県を選択して下さい")}
+      if (formState.targetAgeSelected.length === 0) {newErrors.push("対象年齢を選択して下さい")}
+      if (!formState.teamName?.trim()) {newErrors.push("チーム名を入力してください")}
+      if (!formState.area?.trim()) {newErrors.push("活動地域を入力してください")}
+      if (!formState.sex) {newErrors.push("性別を選択してください")}
+
+      if (newErrors.length > 0) {
+        return { errors: newErrors, formData: currentFormState }
+      }
+
+      try {
+        const disciplineIds = formState.sportsDisciplineSelected.map(discipline => discipline.id)
+        const targetAgeIds = formState.targetAgeSelected.map(target => target.id)
+        
+        await apiClient.post("/teams", {
+          team: { 
+            name: formState.teamName,
+            area: formState.area,
+            sex: formState.sex,
+            track_record: formState.trackRecord,
+            other_body: formState.otherBody,
+            sports_type_id: formState.sportsTypeSelected?.id,
+            sports_discipline_ids: disciplineIds,
+            prefecture_id: formState.prefectureSelected,
+            target_age_ids: targetAgeIds
+          }
+        })
+        
+        navigate("/home")
+        return { errors: [], formData: null }
+      } catch {
+        return {
+          errors: ["チーム登録に失敗しました。入力を確認してください。"],
+          formData: currentFormState
+        }
+      }
+    },
+    { errors: [], formData: null }
+  )
+
+  const ErrorList = (errors: string[]) => {
+    if (errors.length === 0) return null
+  
+    return (
+      <div className="text-red-500 text-sm list-disc list-inside text-left md:pl-44 pl-12">
+        {errors.map((error, index) => (
+          <li key={index}>{error}</li>
+        ))}
+      </div>
+    )
+  }
+
+  useEffect(() => {
+    if (actionState.formData) {
+      setFormState(actionState.formData)
+    }
+  }, [actionState.formData])
+
+  return (
+    <div className="flex items-center justify-center mt-32 md:mt-20">
+      <div className="w-full md:w-3/5 xl:w-2/5 shadow-gray-200 bg-sky-100 rounded-lg">
+        <h2 className="text-center mb-10 pt-10 font-bold text-3xl text-blue-600">チーム紹介作成</h2>
+        <div className="px-4 md:px-0">
+          <form className="px-4 md:px-0 text-center" action={action}>
+            <ul className="space-y-4 text-left">
+
+              {/* 競技種別 */}
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <SelectField
+                    name={TEAM_FIELDS.SPORTS_TYPE}
+                    title="競技名"
+                    value={formState.sportsTypeSelected?.id?? ""}
+                    onChange={handleSportsTypeChange}
+                    options={sportsTypes}
+                  />
+                </div>
+              </li>
+
+              {/* 種目 */}
+              {sportsDisciplines.length > 0 && (
+                <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                  <div className="md:col-span-12 md:ml-2 md:mr-4">
+                    <SelectField
+                      name={TEAM_FIELDS.SPORTS_DISCIPLINE}
+                      multiple
+                      title={<>種目<br />（複数可）</>}
+                      value={formState.sportsDisciplineSelected.map(d => d.id.toString())}
+                      onChange={(e) => handleMultiSelectChange(e, sportsDisciplines, "sportsDisciplineSelected")}
+                      options={sportsDisciplines}
+                    />
+                    {formatSelectedNames(formState.sportsDisciplineSelected)}
+                  </div>
+                </li>
+              )}
+
+              {/* 都道府県 */}
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <SelectField
+                    name={TEAM_FIELDS.PREFECTURE}
+                    title="都道府県"
+                    value={formState.prefectureSelected ? formState.prefectureSelected : ""}
+                    onChange={handlePrefectureChange}
+                    options={prefectures}
+                  />
+                </div>
+              </li>
+
+              {/* チーム名 */}
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <InputField
+                    name={TEAM_FIELDS.NAME}
+                    type="text"
+                    title="チーム名"
+                    placeholder="チーム名"
+                    value={formState.teamName}
+                    onChange={handleInputChange(TEAM_FIELDS.NAME)}
+                  />
+                  {remainingCharactersTeamName <= SHOW_LIMIT_THRESHOLD && (
+                    <div className="text-red-500 text-sm">
+                      チーム名はあと{remainingCharactersTeamName}文字までです。
+                    </div>
+                  )}
+                </div>
+              </li>
+
+              {/* 活動地域 */}
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <TextareaField
+                    name={TEAM_FIELDS.AREA}
+                    title="活動地域"
+                    placeholder="活動地域"
+                    value={formState.area}
+                    onChange={handleInputChange(TEAM_FIELDS.AREA)}
+                    rows={4}
+                  />
+                  {remainingCharactersArea <= SHOW_LIMIT_THRESHOLD && (
+                    <div className="text-red-500 text-sm">
+                      地域はあと{remainingCharactersArea}文字までです。
+                    </div>
+                  )}
+                </div>
+              </li>
+
+              {/* 性別 */}
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <RadioGroupField
+                    name={TEAM_FIELDS.SEX}
+                    title="性別"
+                    options={[
+                      { title: "男", value: "man" },
+                      { title: "女", value: "woman" },
+                      { title: "男女", value: "mix" },
+                      { title: "混合", value: "man_and_woman" }
+                    ]}
+                    selected={formState.sex}
+                    onChange={handleSexChange}
+                  />
+                </div>
+              </li>
+
+              {/* 対象年齢 */}
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <SelectField
+                    name={TEAM_FIELDS.TARGET_AGE}
+                    multiple
+                    title={<>対象年齢<br />（複数可）</>}
+                    value={formState.targetAgeSelected.map(age => age.id.toString())}
+                    onChange={(e) => handleMultiSelectChange(e, targetAges, "targetAgeSelected")}
+                    options={targetAges}
+                  />
+                  {formatSelectedNames(formState.targetAgeSelected)}
+                </div>
+              </li>
+
+              {/* 活動実績 */}
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <TextareaField
+                    name={TEAM_FIELDS.TARGET_RECORD}
+                    title="活動実績"
+                    placeholder="活動実績"
+                    value={formState.trackRecord}
+                    onChange={handleInputChange(TEAM_FIELDS.TARGET_RECORD)}
+                    rows={5}
+                  />
+                  {remainingCharactersTrackRecord <= SHOW_LIMIT_THRESHOLD && (
+                    <div className="text-red-500 text-sm">イベント名はあと{remainingCharactersTrackRecord}文字までです。</div>
+                  )}
+                </div>
+              </li>
+
+              {/* その他 */}
+              <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+                <div className="md:col-span-12 md:ml-2 md:mr-4">
+                  <TextareaField
+                    name={TEAM_FIELDS.OTHER_BODY}
+                    title="その他"
+                    placeholder="その他"
+                    value={formState.otherBody}
+                    onChange={handleInputChange(TEAM_FIELDS.OTHER_BODY)}
+                    rows={5}
+                  />
+                </div>
+              </li>
+            </ul>
+            {ErrorList([...initialErrors, ...disciplineErrors, ...actionState.errors])}
+            {/* 登録ボタン */}
+            <div className="text-center mb-5">
+              <Button variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4">登録する</Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/teamPages/TeamProfilePage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfilePage.tsx
@@ -15,10 +15,10 @@ export default function TeamProfilePage() {
   const navigate = useNavigate()
 
   const [formState, setFormState] = useState({
-    sportsTypeSelected: null as SelectOption | null,
+    sportsTypeSelected: null as SelectOption | null, // TODO: sportsTypeSelectedの初期値を空文字へ修正する対応については後日PRで実施予定
     sportsDisciplineSelected: [] as SelectOption[],
     targetAgeSelected: [] as SelectOption[],
-    prefectureSelected: null as string | null,
+    prefectureSelected: "",
     teamName: "",
     area: "",
     sex: "",
@@ -37,9 +37,6 @@ export default function TeamProfilePage() {
 
   const SHOW_LIMIT_THRESHOLD = 5
   const MAX_LENGTH = 255
-  const remainingCharactersTeamName = MAX_LENGTH - formState.teamName.length
-  const remainingCharactersArea = MAX_LENGTH - formState.area.length
-  const remainingCharactersTrackRecord = MAX_LENGTH - formState.trackRecord.length
 
   const TEAM_FIELDS = {
     SPORTS_TYPE: "teamSportsType",
@@ -52,6 +49,10 @@ export default function TeamProfilePage() {
     TARGET_RECORD: "trackRecord",
     OTHER_BODY: "otherBody"
   }
+
+  const remainingCharactersTeamName = MAX_LENGTH - formState.teamName.length
+  const remainingCharactersArea = MAX_LENGTH - formState.area.length
+  const remainingCharactersTrackRecord = MAX_LENGTH - formState.trackRecord.length
 
   const updateFormState = (field: string, value: unknown) => {
     setFormState(prev => ({ ...prev, [field]: value }))
@@ -204,7 +205,7 @@ export default function TeamProfilePage() {
                   <SelectField
                     name={TEAM_FIELDS.PREFECTURE}
                     title="都道府県"
-                    value={formState.prefectureSelected ? formState.prefectureSelected : ""}
+                    value={formState.prefectureSelected}
                     onChange={handlePrefectureChange}
                     options={prefectures}
                   />

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -12,6 +12,7 @@ import HomePage from "@/pages/HomePage"
 import EventSettingPage from "@/pages/eventPages/EventSettingPage"
 import EventSettingListPage from "@/pages/eventPages/EventSettingListPage"
 import TeamProfileListPage from "@/pages/teamPages/TeamProfileListPage"
+import TeamProfilePage from "@/pages/teamPages/TeamProfilePage"
 import ChatRoomListPage from "@/pages/chatPage/ChatRoomListPage"
 import EventSettingEditPage from "@/pages/eventPages/EventSettingEditPage"
 import BasicSettingEditPage from "@/pages/BasicSettingEditPage"
@@ -66,6 +67,7 @@ export default function AppRouter() {
           <Route path="/event_setting" element={<EventSettingPage />} />
           <Route path="/event_setting_list" element={<EventSettingListPage />} />
           <Route path="/team_profile_list" element={<TeamProfileListPage />} />
+          <Route path="/team_profile" element={<TeamProfilePage />} />
           <Route path="/chat_room_list" element={<ChatRoomListPage />} />
           <Route path="/event_setting_edit/:id" element={<EventSettingEditPage />} />
           <Route path="/basic_setting_edit" element={<BasicSettingEditPage />} />


### PR DESCRIPTION
## 概要
チーム作成用の画面（TeamProfilePage）を新規で実装しました。
## 変更内容
- 競技名、都道府県、チーム名、性別、活動地域、対象年齢、活動実績の新規フォーム
- 入力値に対するバリデーション（例：名前<2〜100文字>、活動地域・活動実績・その他<1〜255文字>）
- 文字数制限に応じた残り文字数のリアルタイム表示
- API通信失敗時のエラーメッセージ表示

close https://github.com/toshinori-m/stay_connect/issues/217