### PR TITLE
イベント詳細ページ（EventPage.tsx）を新規作成

### DIFF
--- a/backend/app/controllers/prefectures_controller.rb
+++ b/backend/app/controllers/prefectures_controller.rb
@@ -20,6 +20,10 @@ class PrefecturesController < ApplicationController
     render json: { message: '成功しました', data: prefectures }, status: 200
   end
 
+  def show
+    @prefecture = Prefecture.find(params[:id])
+  end
+
   def destroy
     prefecture = Prefecture.find(params[:id])
     return render json: { message: '削除に成功しました' }, status: 200 if prefecture.destroy

--- a/backend/app/controllers/sports_types_controller.rb
+++ b/backend/app/controllers/sports_types_controller.rb
@@ -20,6 +20,10 @@ class SportsTypesController < ApplicationController
     render json: { message: '成功しました', data: sports_types }, status: 200
   end
 
+  def show
+    @sports_type = SportsType.find(params[:id])
+  end
+
   def destroy
     sports_type = SportsType.find(params[:id])
     return render json: { message: '削除に成功しました' }, status: 200 if sports_type.destroy

--- a/backend/app/views/prefectures/show.json.jbuilder
+++ b/backend/app/views/prefectures/show.json.jbuilder
@@ -1,0 +1,4 @@
+json.data do
+  json.id @prefecture.id
+  json.name @prefecture.name
+end

--- a/backend/app/views/sports_types/show.json.jbuilder
+++ b/backend/app/views/sports_types/show.json.jbuilder
@@ -1,0 +1,4 @@
+json.data do
+  json.id @sports_type.id
+  json.name @sports_type.name
+end

--- a/frontend-react/src/components/feature/home/SearchForm.tsx
+++ b/frontend-react/src/components/feature/home/SearchForm.tsx
@@ -63,8 +63,6 @@ export default function SearchForm() {
 
   const { sportsDisciplines, errors: sportsDisciplineErrors } = useFetchDisciplines(formState.sportsTypeId)
 
-  const errors = [...initialErrors, ...sportsDisciplineErrors, ...searchErrors]
-
   useEffect(() => {    
     initialSearch()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -208,6 +206,22 @@ export default function SearchForm() {
     }
   }
 
+  const formatOptionNames = (options?: { name: string }[] | null): string => {
+    return options?.length ? options.map(opt => opt.name).join(", ") : ""
+  }
+
+  const ErrorList = (errors: string[]) => {
+    if (errors.length === 0) return null
+
+    return (
+      <div className="text-red-500 text-sm mt-2">
+        {errors.map((error, index) => (
+          <li key={index}>{error}</li>
+        ))}
+      </div>
+    )
+  }
+
   // DetailItemコンポーネントの定義
   const DetailItem = ({ title, value }: DetailItemProps) => (
     <div className="mt-2 break-words w-full md:w-11/12">
@@ -267,14 +281,7 @@ export default function SearchForm() {
 
           <Button type="submit" variant="primary" size="sm" className="my-4 md:mb-0 md:mr-4">検索</Button>
         </form>
-
-        {errors.length > 0 && (
-          <div className="text-red-500 text-sm mt-2">
-            {errors.map((error, index) => (
-              <li key={index}>{error}</li>
-            ))}
-          </div>
-        )}
+        {ErrorList([...initialErrors, ...sportsDisciplineErrors, ...searchErrors])}
       </div>
 
       <div className="md:w-5/6 md:ml-2">
@@ -301,12 +308,12 @@ export default function SearchForm() {
               {recruitment.sports_discipline_name?.length > 0 && (
                 <DetailItem
                   title="種目"
-                  value={recruitment.sports_discipline_name?.map(d => d.name).join(", ") || "なし"}
+                  value={formatOptionNames(recruitment.sports_discipline_name) || "なし"}
                 />
               )}
               <DetailItem title="イベント目的" value={recruitment.purpose_body} />
               <DetailItem title="性別" value={recruitment.sex} />
-              <DetailItem title="対象年齢" value={recruitment.target_age_name?.map(d => d.name).join(", ") || "なし"} />
+              <DetailItem title="対象年齢" value={formatOptionNames(recruitment.target_age_name) || "なし"} />
             </div>
           ))
         )}

--- a/frontend-react/src/components/feature/home/SearchForm.tsx
+++ b/frontend-react/src/components/feature/home/SearchForm.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react"
-import { useActionState } from "react"
+import { useEffect, useState, useActionState } from "react"
+import { useNavigate } from 'react-router-dom'
 import SelectField from "@/components/ui/SelectField"
 import Button from "@/components/ui/Button"
 import { useApiClient } from "@/hooks/useApiClient"
@@ -8,7 +8,7 @@ import useFetchDisciplines from "@/hooks/search/useFetchDisciplines"
 import { SelectOption } from "@/types"
 
 interface DetailItemProps {
-  label: string
+  title: string
   value: string | null
 }
 
@@ -43,6 +43,7 @@ const FORM_FIELD_KEYS = {
 
 export default function SearchForm() {
   const apiClient = useApiClient()
+  const navigate = useNavigate()
   const [recruitments, setRecruitments] = useState<Recruitment[]>([])
   const [searchErrors, setSearchErrors] = useState<string[]>([])
   
@@ -98,7 +99,7 @@ export default function SearchForm() {
           return null
         }
 
-        const selectedOptionName = selectedOption ? selectedOption.name : ""
+        const selectedOptionName = selectedOption?.name ?? ""
         return { id: selectedOptionId, name: selectedOptionName }
       }
 
@@ -198,10 +199,19 @@ export default function SearchForm() {
     }
   }
 
+  const navigateToEventDetail = async (recruitmentId: number) => {
+    try {
+      setSearchErrors([])
+      navigate(`/events/${recruitmentId}`)
+    } catch {
+      setSearchErrors(["イベントを表示できませんでした。"])
+    }
+  }
+
   // DetailItemコンポーネントの定義
-  const DetailItem = ({ label, value }: DetailItemProps) => (
+  const DetailItem = ({ title, value }: DetailItemProps) => (
     <div className="mt-2 break-words w-full md:w-11/12">
-      <span className="text-sm font-semibold text-blue-600">{label}: </span>
+      <span className="text-sm font-semibold text-blue-600">{title}: </span>
       <span className="text-sm mr-2">{value ?? "なし"}</span>
     </div>
   )
@@ -217,7 +227,7 @@ export default function SearchForm() {
           <SelectField
             name={FORM_FIELD_KEYS.SPORTS_TYPE}
             className="ring-offset-2 ring-2 hover:bg-blue-200"
-            value={formState.sportsTypeId ? formState.sportsTypeId.id.toString() : ""}
+            value={formState.sportsTypeId?.id?.toString() ?? ""}
             onChange={(e) => handleChange(e, FORM_FIELD_KEYS.SPORTS_TYPE)}
             options={[{ id: "" as unknown as number, name: "競技選択" }, ...sportsTypes]}
             placeholder="競技選択"
@@ -228,7 +238,7 @@ export default function SearchForm() {
             <SelectField
               name={FORM_FIELD_KEYS.SPORTS_DISCIPLINE}
               className="ring-offset-2 ring-2 hover:bg-blue-200"
-              value={formState.sportsDisciplineId ? formState.sportsDisciplineId.id.toString() : ""}
+              value={formState.sportsDisciplineId?.id?.toString() ?? ""}
               onChange={(e) => handleChange(e, FORM_FIELD_KEYS.SPORTS_DISCIPLINE)}
               options={[{ id: "" as unknown as number, name: "種目選択" }, ...sportsDisciplines]}
               placeholder="種目選択"
@@ -239,7 +249,7 @@ export default function SearchForm() {
           <SelectField
             name={FORM_FIELD_KEYS.PREFECTURE}
             className="ring-offset-2 ring-2 hover:bg-blue-200"
-            value={formState.prefectureId ? formState.prefectureId.id.toString() : ""}
+            value={formState.prefectureId?.id?.toString() ?? ""}
             onChange={(e) => handleChange(e, FORM_FIELD_KEYS.PREFECTURE)}
             options={[{ id: "" as unknown as number, name: "都道府県選択" }, ...prefectures]}
             placeholder="都道府県選択"
@@ -249,7 +259,7 @@ export default function SearchForm() {
           <SelectField
             name={FORM_FIELD_KEYS.TARGET_AGE}
             className="ring-offset-2 ring-2 hover:bg-blue-200"
-            value={formState.targetAgeId ? formState.targetAgeId.id.toString() : ""}
+            value={formState.targetAgeId?.id?.toString() ?? ""}
             onChange={(e) => handleChange(e, FORM_FIELD_KEYS.TARGET_AGE)}
             options={[{ id: "" as unknown as number, name: "対象年齢選択" }, ...targetAges]}
             placeholder="対象年齢選択"
@@ -274,9 +284,12 @@ export default function SearchForm() {
             <p className="mt-2">条件を変更して再検索してください</p>
           </div>
         ) : (
-          // TODO: イベント表示画面への遷移については後日PRで実装する
           recruitments.map((recruitment) => (
-            <div key={recruitment.id} className="max-w-4xl bg-white p-6 rounded-lg shadow-md mb-4">
+            <div
+              key={recruitment.id}
+              className="max-w-4xl bg-white p-6 rounded-lg shadow-md mb-4 hover:bg-blue-200"
+              onClick={() => navigateToEventDetail(recruitment.id)}
+            >
               <div className="flex items-center justify-between">
                 <span className="ml-4 text-sm text-gray-600">{recruitment.prefecture_name}</span>
               </div>
@@ -284,16 +297,16 @@ export default function SearchForm() {
               <h3 className="text-lg font-bold text-blue-600 break-words w-full md:w-11/12">
                 {recruitment.name}
               </h3>
-              <DetailItem label="競技" value={recruitment.sports_type_name} />
+              <DetailItem title="競技" value={recruitment.sports_type_name} />
               {recruitment.sports_discipline_name?.length > 0 && (
                 <DetailItem
-                  label="種目"
+                  title="種目"
                   value={recruitment.sports_discipline_name?.map(d => d.name).join(", ") || "なし"}
                 />
               )}
-              <DetailItem label="イベント目的" value={recruitment.purpose_body} />
-              <DetailItem label="性別" value={recruitment.sex} />
-              <DetailItem label="対象年齢" value={recruitment.target_age_name?.map(d => d.name).join(", ") || "なし"} />
+              <DetailItem title="イベント目的" value={recruitment.purpose_body} />
+              <DetailItem title="性別" value={recruitment.sex} />
+              <DetailItem title="対象年齢" value={recruitment.target_age_name?.map(d => d.name).join(", ") || "なし"} />
             </div>
           ))
         )}

--- a/frontend-react/src/pages/eventPages/EventPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventPage.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from "react"
+import { useParams } from "react-router-dom"
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+import Button from "@/components/ui/Button"
+
+interface EventDetails {
+  name: string
+  image: string
+  user_id: number
+  sports_type_id: number
+  sports_disciplines: SelectOption[]
+  target_ages: SelectOption[]
+  prefecture_id: number
+  area: string
+  purpose_body: string
+  start_date: string
+  end_date: string
+  sex: string
+  number: number
+  other_body: string
+}
+
+export default function EventPage() {
+  const apiClient = useApiClient()
+  const [eventDetails, setEventDetails] = useState<EventDetails | null>(null)
+  const [fetchedEventId, setFetchedEventId] = useState<string | null>(null)
+  const [sportsType, setSportsType] = useState("")
+  const [prefecture, setPrefecture] = useState("")
+  const [errors, setErrors] = useState<string[]>([])
+  const { id: eventId } = useParams()
+
+  const sportsDisciplinesNames = () => {
+    if (eventDetails && eventDetails.sports_disciplines?.length > 0) {
+      return eventDetails.sports_disciplines.map(sd => sd.name).join(", ")
+    }
+    return ""
+  }
+
+  const targetAgesNames = () => {
+    if (eventDetails && eventDetails.target_ages?.length > 0) {
+      return eventDetails.target_ages.map(age => age.name).join(", ")
+    }
+    return ""
+  }
+
+  useEffect(() => {
+
+    setErrors([])
+
+    if (!eventId || fetchedEventId === eventId) return
+    console.log("getSportsType")
+
+    fetchEventDetails(eventId)
+    .then(eventData => {
+      setEventDetails(eventData)
+      setFetchedEventId(eventId)
+      return Promise.all([
+        fetchSportsType(eventData.sports_type_id),
+        fetchPrefecture(eventData.prefecture_id)
+      ])
+    })
+    .then(([foundSportsType, foundPrefecture]) => {
+      setSportsType(foundSportsType?.name || "")
+      setPrefecture(foundPrefecture?.name || "")
+    })
+    .catch(() => {
+      setErrors(["基本設定を表示できませんでした。"])
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventId])
+
+  const fetchEventDetails = async (eventId: string) => {
+    const eventData = (await apiClient.get(`/recruitments/${eventId}`)).data.data
+    return eventData
+  }
+
+  const fetchSportsType = async (sportsTypeId: number | null) => {
+    if (!sportsTypeId) return Promise.resolve(null)
+    const sportsTypeDate = (await apiClient.get(`/sports_types/${sportsTypeId}`)).data.data
+    return sportsTypeDate
+  }
+
+  const fetchPrefecture = async (prefectureId: number | null) => {
+    if (!prefectureId) return Promise.resolve(null)
+    const prefectureData = (await apiClient.get(`/prefectures/${prefectureId}`)).data.data
+    return prefectureData
+  }
+
+  const goToUserProfile = () => {
+    console.log("代表紹介編集画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  }
+
+  const TitleAndText = ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <p className="mb-5">
+      <span className="font-semibold text-blue-600">{title}:</span> {children}
+    </p>
+  )
+
+  if (!eventDetails) return
+
+  return (
+    <div className="mt-40 md:mt-20 max-w-2xl mx-auto p-6 bg-sky-100 shadow-lg rounded-lg break-words">
+      <h1 className="text-2xl font-light mb-4">
+        <span className="font-bold mr-3 text-blue-600">イベント名:</span>
+        {eventDetails.name}
+      </h1>
+      {eventDetails.image && (
+        <img src={eventDetails.image} alt="Event Image" className="w-full h-auto mb-4" />
+      )}
+      <div className="text-right">
+        <Button
+          type="submit"
+          variant="primary"
+          size="sm"
+          className="mr-4"
+          onClick={() => goToUserProfile()}
+        >
+          代表紹介
+        </Button>
+      </div>
+      {errors.map((errMsg, index) => (
+        <div key={index} className="text-sm text-red-400">{errMsg}</div>
+      ))}
+      <TitleAndText title="競技">{sportsType}</TitleAndText>
+
+      {eventDetails.sports_disciplines?.length > 0 && (
+        <TitleAndText title="種目">{sportsDisciplinesNames()}</TitleAndText>
+      )}
+
+      <TitleAndText title="都道府県">{prefecture}</TitleAndText>
+      <TitleAndText title="開催地">{eventDetails.area}</TitleAndText>
+      <TitleAndText title="対象年齢">{targetAgesNames()}</TitleAndText>
+      <TitleAndText title="目的">{eventDetails.purpose_body}</TitleAndText>
+      <TitleAndText title="開始日">{eventDetails.start_date}</TitleAndText>
+      <TitleAndText title="終了日">{eventDetails.end_date}</TitleAndText>
+      <TitleAndText title="性別">{eventDetails.sex}</TitleAndText>
+      <TitleAndText title="チーム数">{eventDetails.number}</TitleAndText>
+      <TitleAndText title="その他">{eventDetails.other_body}</TitleAndText>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/eventPages/EventPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventPage.tsx
@@ -30,22 +30,14 @@ export default function EventPage() {
   const [errors, setErrors] = useState<string[]>([])
   const { id: eventId } = useParams()
 
-  const sportsDisciplinesNames = () => {
-    if (eventDetails && eventDetails.sports_disciplines?.length > 0) {
-      return eventDetails.sports_disciplines.map(sd => sd.name).join(", ")
-    }
-    return ""
+  const formatOptionNames = (options?: { name: string }[] | null): string => {
+    return options?.length ? options.map(opt => opt.name).join(", ") : ""
   }
 
-  const targetAgesNames = () => {
-    if (eventDetails && eventDetails.target_ages?.length > 0) {
-      return eventDetails.target_ages.map(age => age.name).join(", ")
-    }
-    return ""
-  }
+  const sportsDisciplinesNames = () => formatOptionNames(eventDetails?.sports_disciplines)
+  const targetAgesNames = () => formatOptionNames(eventDetails?.target_ages)
 
   useEffect(() => {
-
     setErrors([])
 
     if (!eventId || fetchedEventId === eventId) return
@@ -87,11 +79,11 @@ export default function EventPage() {
     return prefectureData
   }
 
-  const goToUserProfile = () => {
+  const handleUserProfileClick = () => {
     console.log("代表紹介編集画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
   }
 
-  const TitleAndText = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  const TitleAndValue = ({ title, children }: { title: string; children: React.ReactNode }) => (
     <p className="mb-5">
       <span className="font-semibold text-blue-600">{title}:</span> {children}
     </p>
@@ -114,7 +106,7 @@ export default function EventPage() {
           variant="primary"
           size="sm"
           className="mr-4"
-          onClick={() => goToUserProfile()}
+          onClick={() => handleUserProfileClick()}
         >
           代表紹介
         </Button>
@@ -122,21 +114,21 @@ export default function EventPage() {
       {errors.map((errMsg, index) => (
         <div key={index} className="text-sm text-red-400">{errMsg}</div>
       ))}
-      <TitleAndText title="競技">{sportsType}</TitleAndText>
+      <TitleAndValue title="競技">{sportsType}</TitleAndValue>
 
       {eventDetails.sports_disciplines?.length > 0 && (
-        <TitleAndText title="種目">{sportsDisciplinesNames()}</TitleAndText>
+        <TitleAndValue title="種目">{sportsDisciplinesNames()}</TitleAndValue>
       )}
 
-      <TitleAndText title="都道府県">{prefecture}</TitleAndText>
-      <TitleAndText title="開催地">{eventDetails.area}</TitleAndText>
-      <TitleAndText title="対象年齢">{targetAgesNames()}</TitleAndText>
-      <TitleAndText title="目的">{eventDetails.purpose_body}</TitleAndText>
-      <TitleAndText title="開始日">{eventDetails.start_date}</TitleAndText>
-      <TitleAndText title="終了日">{eventDetails.end_date}</TitleAndText>
-      <TitleAndText title="性別">{eventDetails.sex}</TitleAndText>
-      <TitleAndText title="チーム数">{eventDetails.number}</TitleAndText>
-      <TitleAndText title="その他">{eventDetails.other_body}</TitleAndText>
+      <TitleAndValue title="都道府県">{prefecture}</TitleAndValue>
+      <TitleAndValue title="開催地">{eventDetails.area}</TitleAndValue>
+      <TitleAndValue title="対象年齢">{targetAgesNames()}</TitleAndValue>
+      <TitleAndValue title="目的">{eventDetails.purpose_body}</TitleAndValue>
+      <TitleAndValue title="開始日">{eventDetails.start_date}</TitleAndValue>
+      <TitleAndValue title="終了日">{eventDetails.end_date}</TitleAndValue>
+      <TitleAndValue title="性別">{eventDetails.sex}</TitleAndValue>
+      <TitleAndValue title="チーム数">{eventDetails.number}</TitleAndValue>
+      <TitleAndValue title="その他">{eventDetails.other_body}</TitleAndValue>
     </div>
   )
 }

--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -298,6 +298,10 @@ export default function EventSettingForm() {
     }
   }
 
+  const formatOptionNames = (options?: { name: string }[] | null): string => {
+    return options?.length ? options.map(opt => opt.name).join(", ") : ""
+  }
+
   const ErrorList = (errors: string[]) => {
     if (errors.length === 0) return null
 
@@ -337,7 +341,7 @@ export default function EventSettingForm() {
                     name="eventSportsDiscipline"
                     multiple
                     title={<>種目<br />（複数可）</>}
-                    value={formState.sportsDisciplineSelected.map(d => d.id.toString())}
+                    value={formatOptionNames(formState?.sportsDisciplineSelected)}
                     options={sportsDisciplines}
                     onChange={(e) => handleMultiSelectChange(e, sportsDisciplines, 'sportsDisciplineSelected')}
                   />

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -9,11 +9,12 @@ import LoginPage from "@/pages/LoginPage"
 import SignupPage from "@/pages/SignupPage"
 import RegisterPage from "@/pages/RegisterPage"
 import HomePage from "@/pages/HomePage"
+import EventPage from "@/pages/eventPages/EventPage"
 import EventSettingPage from "@/pages/eventPages/EventSettingPage"
 import EventSettingListPage from "@/pages/eventPages/EventSettingListPage"
+import EventSettingEditPage from "@/pages/eventPages/EventSettingEditPage"
 import TeamProfileListPage from "@/pages/teamPages/TeamProfileListPage"
 import ChatRoomListPage from "@/pages/chatPage/ChatRoomListPage"
-import EventSettingEditPage from "@/pages/eventPages/EventSettingEditPage"
 import BasicSettingEditPage from "@/pages/BasicSettingEditPage"
 
 function OpenLayout() {
@@ -63,11 +64,12 @@ export default function AppRouter() {
       <Route element={<RequireAuth />}>
         <Route element={<HomeLayout />}>
           <Route path="/home" element={<HomePage />} />
+          <Route path="/events/:id" element={<EventPage />} />
           <Route path="/event_setting" element={<EventSettingPage />} />
           <Route path="/event_setting_list" element={<EventSettingListPage />} />
+          <Route path="/event_setting_edit/:id" element={<EventSettingEditPage />} />
           <Route path="/team_profile_list" element={<TeamProfileListPage />} />
           <Route path="/chat_room_list" element={<ChatRoomListPage />} />
-          <Route path="/event_setting_edit/:id" element={<EventSettingEditPage />} />
           <Route path="/basic_setting_edit" element={<BasicSettingEditPage />} />
         </Route>
       </Route>


### PR DESCRIPTION
### 概要
イベント詳細ページ（EventPage.tsx）を新規で実装しました。
### 変更内容
- `/recruitments/:id` に基づき、イベントの詳細情報を取得・表示
- 関連情報（競技種別・種目・対象年齢・都道府県）も ID に基づいて取得し、名前として表示
- 表示部分を `TitleAndText` コンポーネントで整理し、可読性を向上
- エラーハンドリングとローディング制御を実装
### 補足
- 今後の機能追加（代表紹介ページ遷移）は `goToUserProfile` にて対応予定（TODOコメントあり）

close https://github.com/toshinori-m/stay_connect/issues/214