### PR TITLE
チーム代表紹介画面を新規作成

### DIFF
--- a/frontend-react/src/pages/UserProfilePage.tsx
+++ b/frontend-react/src/pages/UserProfilePage.tsx
@@ -1,0 +1,194 @@
+import { useState, useEffect } from "react"
+import { useQuery } from '@tanstack/react-query'
+import { useParams, useNavigate } from "react-router-dom"
+import { useApiClient } from "@/hooks/useApiClient"
+import Button from "@/components/ui/Button"
+import { SelectOption } from "@/types"
+
+interface UserProfile {
+  id: number
+  name: string
+  sex: string
+  self_introduction: string
+  image_url: string
+}
+
+export default function UserProfilePage() {
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null)
+  const [currentUser, setCurrentUser] = useState<SelectOption | null>(null)
+  const [teams, setTeams] = useState<SelectOption[]>([])
+  const [errors, setErrors] = useState<string[]>([])
+  const { userId } = useParams()
+  const navigate = useNavigate()
+  const apiClient = useApiClient()
+
+  // ユーザープロフィールの取得
+  const { 
+    data: profileData,
+    error: profileError
+  } = useQuery({
+    queryKey: ['userProfile', userId],
+    queryFn: async () => {
+      const res = await apiClient.get(`/users_profile/${userId}`);
+      return res.data.data;
+    },
+    enabled: !!userId // userIdが存在する場合のみクエリを実行
+  });
+
+  // チーム情報の取得（プロフィールデータが取得できた後）
+  const {
+    data: teamsData,
+    error: teamsError
+  } = useQuery({
+    queryKey: ['userTeams', profileData?.id],
+    queryFn: async () => {
+      const res = await apiClient.get(`/users/${profileData.id}/teams_profile`);
+      return res.data.data || res.data || [];
+    },
+    enabled: !!profileData?.id // profileData.idが存在する場合のみクエリを実行
+  });
+
+  // 現在のユーザー情報の取得
+  const {
+    data: currentUserData,
+    error: currentUserError
+  } = useQuery({
+    queryKey: ['currentUser'],
+    queryFn: async () => {
+      const res = await apiClient.get("/users/show");
+      return res.data.data;
+    }
+  });
+
+  // データが取得できたら状態を更新
+  useEffect(() => {
+    if (profileData) setUserProfile(profileData);
+  }, [profileData]);
+
+  useEffect(() => {
+    if (teamsData) setTeams(teamsData);
+  }, [teamsData]);
+
+  useEffect(() => {
+    if (currentUserData) setCurrentUser(currentUserData);
+  }, [currentUserData]);
+
+  // エラー処理を統合
+  useEffect(() => {
+    const newErrors = [];
+    
+    if (profileError) {
+      console.error("プロフィール取得エラー:", profileError);
+      newErrors.push("自己紹介画面を表示できませんでした。");
+    }
+    
+    if (teamsError) {
+      console.error("チーム情報取得エラー:", teamsError);
+      newErrors.push("チーム情報を取得できませんでした。");
+    }
+    
+    if (currentUserError) {
+      console.error("現在のユーザー取得エラー:", currentUserError);
+      newErrors.push("ユーザー情報を取得できませんでした。");
+    }
+    
+    if (newErrors.length > 0) {
+      setErrors(newErrors);
+    }
+  }, [profileError, teamsError, currentUserError]);
+
+  // 単純なナビゲーション関数ではtry-catchは不要
+  const handleTeamIntroduction = (teamId: number) => {
+    if (!teamId) {
+      setErrors(prev => [...prev, "チームIDが指定されていません。"])
+      return
+    }
+    navigate(`/teams/${teamId}`)
+  }
+
+  const showChatButton = () => {
+    // userProfile と currentUser の両方が存在し、IDが異なる場合のみボタンを表示
+    return userProfile?.id && currentUser?.id && userProfile.id !== currentUser.id
+  }
+
+  const handleChatRoom = async () => {
+    setErrors([])
+    try {
+      if (!userProfile?.id) {
+        setErrors(prev => [...prev, "ユーザーIDが取得できませんでした。"])
+        return
+      }
+      const res = await apiClient.post("/chat_rooms", {
+        other_user_id: userProfile.id
+      })
+      navigate(`/chat-rooms/${res.data.data.id}`)
+    } catch {
+      setErrors(prev => [...prev, "チャットルーム画面を表示できませんでした。"])
+    }
+  }
+
+  return (
+    <div className="mt-40 md:mt-20 max-w-2xl mx-auto p-6 bg-sky-100 shadow-lg rounded-lg break-words">
+      {errors.length > 0 && errors.map((errMsg, index) => (
+        <div key={index} className="error text-sm text-red-400">
+          {errMsg}
+        </div>
+      ))}
+      
+      <div className="flex items-center">
+        <div className="w-32 h-32 rounded-full overflow-hidden">
+          <img 
+            src={userProfile?.image_url || "/api/placeholder/100/100"} 
+            alt={userProfile?.name ? `${userProfile.name}のプロフィール画像` : "ユーザー画像"} 
+            className="object-cover w-full h-full"
+          />
+        </div>
+        <div className="ml-4">
+          {showChatButton() && (
+            <Button
+              variant="primary"
+              size="sm"
+              className="mt-2 mb-2 px-4 py-2"
+              onClick={handleChatRoom}
+            >
+              チーム代表とチャット開始
+            </Button>
+          )}
+        </div>
+      </div>
+      
+      <p className="mt-4 font-semibold text-blue-600">所属チーム紹介:</p>
+      {teams.length > 0 ? (
+        <ul>
+          {teams.map(team => (
+            <li key={team.id}>
+              <Button
+                variant="primary"
+                size="sm"
+                className="max-w-full text-left mt-2 mb-2 px-4 py-2"
+                onClick={() => handleTeamIntroduction(team.id)}
+              >
+                {team.name}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-red-400">チーム情報が存在しません。</p>
+      )}
+      
+      <p className="mb-2">
+        <span className="font-semibold text-blue-600">名前:</span>{" "}
+        {userProfile?.name || "情報なし"}
+      </p>
+      <p className="mb-2">
+        <span className="font-semibold text-blue-600">性別:</span>{" "}
+        {userProfile?.sex || "情報なし"}
+      </p>
+      <p className="mb-2">
+        <span className="font-semibold text-blue-600">自己紹介:</span>{" "}
+        {userProfile?.self_introduction || "情報なし"}
+      </p>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/UserProfilePage.tsx
+++ b/frontend-react/src/pages/UserProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { useParams } from "react-router-dom"
 import { useApiClient } from "@/hooks/useApiClient"
@@ -39,15 +39,13 @@ export default function UserProfilePage() {
     },
   })
 
-  // エラー処理
-  useEffect(() => {
-    const newErrors = []
-
-    if (profileError) {newErrors.push("自己紹介画面を表示できませんでした。")}
-    if (teamsError) {newErrors.push("チーム情報を取得できませんでした。")}
-    if (currentUserError) {newErrors.push("ユーザー情報を取得できませんでした。")}
-    if (newErrors.length > 0) {setErrors(newErrors)}
-  }, [profileError, teamsError, currentUserError])
+  // エラーを直接構築
+  const errorMessages = [
+    profileError && "自己紹介画面を表示できませんでした。",
+    teamsError && "チーム情報を取得できませんでした。",
+    currentUserError && "ユーザー情報を取得できませんでした。",
+    ...errors
+  ].filter(Boolean) as string[]
 
   // チーム紹介ページへ
   const handleTeamIntroduction = (teamId: number) => {
@@ -98,7 +96,7 @@ export default function UserProfilePage() {
 
   return (
     <div className="mt-40 md:mt-20 max-w-2xl mx-auto p-6 bg-sky-100 shadow-lg rounded-lg break-words">
-      {ErrorList([...errors])}
+      {ErrorList(errorMessages)}
 
       <div className="flex items-center">
         <div className="w-32 h-32 rounded-full overflow-hidden">

--- a/frontend-react/src/pages/UserProfilePage.tsx
+++ b/frontend-react/src/pages/UserProfilePage.tsx
@@ -1,116 +1,69 @@
-import { useState, useEffect } from "react"
-import { useQuery } from '@tanstack/react-query'
-import { useParams, useNavigate } from "react-router-dom"
+import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useParams } from "react-router-dom"
 import { useApiClient } from "@/hooks/useApiClient"
 import Button from "@/components/ui/Button"
 import { SelectOption } from "@/types"
 
-interface UserProfile {
-  id: number
-  name: string
-  sex: string
-  self_introduction: string
-  image_url: string
-}
-
 export default function UserProfilePage() {
-  const [userProfile, setUserProfile] = useState<UserProfile | null>(null)
-  const [currentUser, setCurrentUser] = useState<SelectOption | null>(null)
-  const [teams, setTeams] = useState<SelectOption[]>([])
   const [errors, setErrors] = useState<string[]>([])
   const { userId } = useParams()
-  const navigate = useNavigate()
   const apiClient = useApiClient()
 
-  // ユーザープロフィールの取得
-  const { 
-    data: profileData,
-    error: profileError
-  } = useQuery({
-    queryKey: ['userProfile', userId],
+  // ユーザープロフィール取得
+  const { data: userProfile, error: profileError } = useQuery({
+    queryKey: ["userProfile", userId],
     queryFn: async () => {
-      const res = await apiClient.get(`/users_profile/${userId}`);
-      return res.data.data;
+      const userProfileRes = (await apiClient.get(`/users_profile/${userId}`)).data.data
+      return userProfileRes
     },
-    enabled: !!userId // userIdが存在する場合のみクエリを実行
-  });
+    enabled: !!userId,
+  })
 
-  // チーム情報の取得（プロフィールデータが取得できた後）
-  const {
-    data: teamsData,
-    error: teamsError
-  } = useQuery({
-    queryKey: ['userTeams', profileData?.id],
+  // チーム情報取得
+  const { data: teams = [], error: teamsError } = useQuery<SelectOption[]>({
+    queryKey: ["userTeams", userProfile?.id],
     queryFn: async () => {
-      const res = await apiClient.get(`/users/${profileData.id}/teams_profile`);
-      return res.data.data || res.data || [];
+      const teamsRes = (await apiClient.get(`/users/${userProfile.id}/teams_profile`)).data
+      return teamsRes
     },
-    enabled: !!profileData?.id // profileData.idが存在する場合のみクエリを実行
-  });
+    enabled: !!userProfile?.id,
+  })
 
-  // 現在のユーザー情報の取得
-  const {
-    data: currentUserData,
-    error: currentUserError
-  } = useQuery({
-    queryKey: ['currentUser'],
+  // 現在のユーザー取得
+  const { data: currentUser, error: currentUserError } = useQuery({
+    queryKey: ["currentUser"],
     queryFn: async () => {
-      const res = await apiClient.get("/users/show");
-      return res.data.data;
-    }
-  });
+      const currentUserRes = (await apiClient.get("/users/show")).data.data
+      return currentUserRes
+    },
+  })
 
-  // データが取得できたら状態を更新
+  // エラー処理
   useEffect(() => {
-    if (profileData) setUserProfile(profileData);
-  }, [profileData]);
+    const newErrors = []
 
-  useEffect(() => {
-    if (teamsData) setTeams(teamsData);
-  }, [teamsData]);
+    if (profileError) {newErrors.push("自己紹介画面を表示できませんでした。")}
+    if (teamsError) {newErrors.push("チーム情報を取得できませんでした。")}
+    if (currentUserError) {newErrors.push("ユーザー情報を取得できませんでした。")}
+    if (newErrors.length > 0) {setErrors(newErrors)}
+  }, [profileError, teamsError, currentUserError])
 
-  useEffect(() => {
-    if (currentUserData) setCurrentUser(currentUserData);
-  }, [currentUserData]);
-
-  // エラー処理を統合
-  useEffect(() => {
-    const newErrors = [];
-    
-    if (profileError) {
-      console.error("プロフィール取得エラー:", profileError);
-      newErrors.push("自己紹介画面を表示できませんでした。");
-    }
-    
-    if (teamsError) {
-      console.error("チーム情報取得エラー:", teamsError);
-      newErrors.push("チーム情報を取得できませんでした。");
-    }
-    
-    if (currentUserError) {
-      console.error("現在のユーザー取得エラー:", currentUserError);
-      newErrors.push("ユーザー情報を取得できませんでした。");
-    }
-    
-    if (newErrors.length > 0) {
-      setErrors(newErrors);
-    }
-  }, [profileError, teamsError, currentUserError]);
-
-  // 単純なナビゲーション関数ではtry-catchは不要
+  // チーム紹介ページへ
   const handleTeamIntroduction = (teamId: number) => {
     if (!teamId) {
       setErrors(prev => [...prev, "チームIDが指定されていません。"])
       return
     }
-    navigate(`/teams/${teamId}`)
+    console.log("チーム紹介画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
   }
 
+  // チャットボタン表示条件
   const showChatButton = () => {
-    // userProfile と currentUser の両方が存在し、IDが異なる場合のみボタンを表示
     return userProfile?.id && currentUser?.id && userProfile.id !== currentUser.id
   }
 
+  // チャット開始処理
   const handleChatRoom = async () => {
     setErrors([])
     try {
@@ -118,23 +71,35 @@ export default function UserProfilePage() {
         setErrors(prev => [...prev, "ユーザーIDが取得できませんでした。"])
         return
       }
-      const res = await apiClient.post("/chat_rooms", {
-        other_user_id: userProfile.id
-      })
-      navigate(`/chat-rooms/${res.data.data.id}`)
+      console.log("パスワード再設定メール送信画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
     } catch {
       setErrors(prev => [...prev, "チャットルーム画面を表示できませんでした。"])
     }
   }
 
+  const ErrorList = (errors: string[]) => {
+    if (errors.length === 0) return null
+
+    return (
+      <ul className="text-sm text-red-500 mt-3 mb-6">
+        {errors.map((error, index) => (
+          <li key={index}>{error}</li>
+        ))}
+      </ul>
+    )
+  }
+
+  const ProfileItem = ({ label, value }: { label: string; value?: string }) => (
+    <p className="mb-2">
+      <span className="font-semibold text-blue-600">{label}:</span>{" "}
+      {value || "情報なし"}
+    </p>
+  )
+
   return (
     <div className="mt-40 md:mt-20 max-w-2xl mx-auto p-6 bg-sky-100 shadow-lg rounded-lg break-words">
-      {errors.length > 0 && errors.map((errMsg, index) => (
-        <div key={index} className="error text-sm text-red-400">
-          {errMsg}
-        </div>
-      ))}
-      
+      {ErrorList([...errors])}
+
       <div className="flex items-center">
         <div className="w-32 h-32 rounded-full overflow-hidden">
           <img 
@@ -145,50 +110,29 @@ export default function UserProfilePage() {
         </div>
         <div className="ml-4">
           {showChatButton() && (
-            <Button
-              variant="primary"
-              size="sm"
-              className="mt-2 mb-2 px-4 py-2"
-              onClick={handleChatRoom}
-            >
+            <Button variant="primary" size="sm" className="mt-2 mb-2 px-4 py-2" onClick={handleChatRoom}>
               チーム代表とチャット開始
             </Button>
           )}
         </div>
       </div>
-      
+
       <p className="mt-4 font-semibold text-blue-600">所属チーム紹介:</p>
-      {teams.length > 0 ? (
-        <ul>
-          {teams.map(team => (
-            <li key={team.id}>
-              <Button
-                variant="primary"
-                size="sm"
-                className="max-w-full text-left mt-2 mb-2 px-4 py-2"
-                onClick={() => handleTeamIntroduction(team.id)}
-              >
-                {team.name}
-              </Button>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="text-sm text-red-400">チーム情報が存在しません。</p>
-      )}
-      
-      <p className="mb-2">
-        <span className="font-semibold text-blue-600">名前:</span>{" "}
-        {userProfile?.name || "情報なし"}
-      </p>
-      <p className="mb-2">
-        <span className="font-semibold text-blue-600">性別:</span>{" "}
-        {userProfile?.sex || "情報なし"}
-      </p>
-      <p className="mb-2">
-        <span className="font-semibold text-blue-600">自己紹介:</span>{" "}
-        {userProfile?.self_introduction || "情報なし"}
-      </p>
+      <ul>
+        {teams.map(team => (
+          <li key={team.id}>
+            <Button variant="primary" size="sm" className="max-w-full text-left mt-2 mb-2 px-4 py-2"
+              onClick={() => handleTeamIntroduction(team.id)}
+            >
+              {team.name}
+            </Button>
+          </li>
+        ))}
+      </ul>
+
+      <ProfileItem label="名前" value={userProfile?.name} />
+      <ProfileItem label="性別" value={userProfile?.sex} />
+      <ProfileItem label="自己紹介" value={userProfile?.self_introduction} />
     </div>
   )
 }

--- a/frontend-react/src/pages/eventPages/EventPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "react-router-dom"
+import { useParams, useNavigate } from "react-router-dom"
 import { useApiClient } from "@/hooks/useApiClient"
 import { SelectOption } from "@/types"
 import Button from "@/components/ui/Button"
@@ -23,6 +23,7 @@ interface EventDetails {
 
 export default function EventPage() {
   const apiClient = useApiClient()
+  const navigate = useNavigate()
   const [eventDetails, setEventDetails] = useState<EventDetails | null>(null)
   const [fetchedEventId, setFetchedEventId] = useState<string | null>(null)
   const [sportsType, setSportsType] = useState("")
@@ -41,7 +42,6 @@ export default function EventPage() {
     setErrors([])
 
     if (!eventId || fetchedEventId === eventId) return
-    console.log("getSportsType")
 
     fetchEventDetails(eventId)
     .then(eventData => {
@@ -69,8 +69,8 @@ export default function EventPage() {
 
   const fetchSportsType = async (sportsTypeId: number | null) => {
     if (!sportsTypeId) return Promise.resolve(null)
-    const sportsTypeDate = (await apiClient.get(`/sports_types/${sportsTypeId}`)).data.data
-    return sportsTypeDate
+    const sportsTypeData = (await apiClient.get(`/sports_types/${sportsTypeId}`)).data.data
+    return sportsTypeData
   }
 
   const fetchPrefecture = async (prefectureId: number | null) => {
@@ -80,7 +80,9 @@ export default function EventPage() {
   }
 
   const handleUserProfileClick = () => {
-    console.log("代表紹介編集画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+    if (eventDetails?.user_id) {
+      navigate(`/user_profile/${eventDetails.user_id}`)
+    }
   }
 
   const TitleAndValue = ({ title, children }: { title: string; children: React.ReactNode }) => (

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -17,6 +17,7 @@ import TeamProfileListPage from "@/pages/teamPages/TeamProfileListPage"
 import TeamProfilePage from "@/pages/teamPages/TeamProfilePage"
 import ChatRoomListPage from "@/pages/chatPage/ChatRoomListPage"
 import BasicSettingEditPage from "@/pages/BasicSettingEditPage"
+import UserProfilePage from "@/pages/UserProfilePage"
 
 function OpenLayout() {
   return (
@@ -73,6 +74,7 @@ export default function AppRouter() {
           <Route path="/team_profile" element={<TeamProfilePage />} />
           <Route path="/chat_room_list" element={<ChatRoomListPage />} />
           <Route path="/basic_setting_edit" element={<BasicSettingEditPage />} />
+          <Route path="/user_profile/:userId" element={<UserProfilePage />} />
         </Route>
       </Route>
     </Routes>


### PR DESCRIPTION
### 概要
- ユーザーのプロフィールを表示する画面（UserProfilePage）を新規で実装しました。
### 変更内容
- 該当ユーザーの情報（名前、性別、自己紹介）および所属チームの一覧を取得・表示。
- 現在のログインユーザーと異なる場合のみ「チャット開始ボタン」を表示。
- API取得時のエラー表示機能を実装。


close https://github.com/toshinori-m/stay_connect/issues/228