### PR TITLE
チーム紹介編集画面を新規作成

### DIFF
--- a/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventSettingEditPage.tsx
@@ -505,7 +505,7 @@ export default function EventSettingForm() {
           {/* 登録ボタン */}
           <div className="text-center my-5">
             <Button type="submit" variant="primary" size="sm" className="mr-4">更新</Button>
-            <Button type="submit" variant="red" size="sm" onClick={recruitmentHandleDelete}>削除</Button>
+            <Button type="button" variant="red" size="sm" onClick={recruitmentHandleDelete}>削除</Button>
           </div>
         </form>
       </div>

--- a/frontend-react/src/pages/teamPages/TeamProfileEditPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileEditPage.tsx
@@ -1,0 +1,326 @@
+import { useEffect, useState } from "react"
+import { useParams } from "react-router-dom"
+import { useApiClient } from "@/hooks/useApiClient"
+import { SelectOption } from "@/types"
+import useInitialFormData from "@/hooks/search/useInitialFormData"
+import useFetchDisciplines from "@/hooks/search/useFetchDisciplines"
+import InputField from "@/components/ui/InputField"
+import TextareaField from "@/components/ui/TextareaField"
+import SelectField from "@/components/ui/SelectField"
+import RadioGroupField from "@/components/ui/RadioGroupField"
+
+interface TeamData {
+  id: number
+  name: string
+  area: string
+  sex: string
+  track_record: string
+  other_body: string
+  sports_type_id: number
+  prefecture_id: number
+}
+// まずは表示側の実装部分のみレビューをお願いします。編集・保存処理は次のコミットで追加予定です。
+export default function TeamProfileEditPage() {
+  const { id: teamId } = useParams<{ id: string }>()
+  const apiClient = useApiClient()
+
+  const EVENT_FIELDS = {
+    SPORTS_TYPE: "teamSportsType",
+    SPORTS_DISCIPLINE: "teamSportsDiscipline",
+    PREFECTURE: "teamPrefecture",
+    TARGET_AGE: "teamTargetAge",
+    NAME: "teamName",
+    AREA: "teamArea",
+    SEX: "teamSex",
+    TRACK_RECORD: "teamTrackRecord",
+    OTHER_BODY: "teamOtherBody"
+  }
+
+  const [formState, setFormState] = useState({
+    sportsTypeSelected: "",
+    sportsDisciplineSelected: [],
+    targetAgeSelected: [],
+    prefectureSelected: "",
+    name: "",
+    area: "",
+    sex: "",
+    trackRecord: "",
+    otherBody: ""
+  })
+  
+  const [errors, setErrors] = useState<string[]>([])
+  const [fetchedId, setFetchedId] = useState<string | null>(null)
+  const [pendingSportsDisciplineIds, setPendingSportsDisciplineIds] = useState<number[] | null>(null)
+
+  const {
+    sportsTypes,
+    prefectures,
+    targetAges,
+    errors: initialErrors
+  } = useInitialFormData()
+
+  const { sportsDisciplines, errors: sportsDisciplineErrors } = useFetchDisciplines(formState.sportsTypeSelected)
+
+  useEffect(() => {
+    setErrors([])
+    if (fetchedId === teamId) return
+    if (sportsTypes.length === 0 || prefectures.length === 0 || targetAges.length === 0) return
+    if (!teamId) return
+
+    fetchTeamData(teamId)
+    .then(({ teamData, sportsDisciplineIds, targetAgeIds }) => {
+      if (!teamData) return
+
+      setTeamFormState(teamData)
+      setSelectedSportsType(teamData.sports_type_id)
+      setSelectedTargetAge(targetAgeIds)
+      setPendingSportsDisciplineIds(sportsDisciplineIds)
+      setFetchedId(teamId)
+    })
+    .catch(() => {
+      setErrors(["チーム紹介を表示できませんでした。"])
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamId, sportsTypes, prefectures, targetAges])
+
+  const fetchTeamData = async (teamId: string) => {
+    const teamData = (await apiClient.get(`/teams/${teamId}`)).data.data
+    const sportsDisciplineIds = teamData.sports_disciplines
+    const targetAgeIds = teamData.target_ages
+    return { teamData, sportsDisciplineIds, targetAgeIds }
+  }  
+
+  const setTeamFormState = (teamData: TeamData) => {
+    setFormState(prev => ({
+      ...prev,
+      name: teamData.name || "",
+      area: teamData.area || "",
+      sex: teamData.sex || "",
+      prefectureSelected: teamData.prefecture_id ? teamData.prefecture_id.toString() : "",
+      trackRecord: teamData.track_record || "",
+      otherBody: teamData.other_body || ""
+    }))
+  }  
+
+  const setSelectedSportsType = (selectSportsTypeId?: number) => {
+    if (selectSportsTypeId) {
+      updateFormState("sportsTypeSelected", selectSportsTypeId.toString())
+    }
+  }
+
+  const setSelectedTargetAge = (targetAgeIds?: number[]) => {
+    if (targetAgeIds && targetAgeIds.length > 0) {
+      const selectedIds = targetAgeIds.map(targetAgeId => targetAgeId.toString())
+      updateFormState("targetAgeSelected", selectedIds)
+    }
+  }
+
+  useEffect(() => {
+    if (!pendingSportsDisciplineIds || sportsDisciplines.length === 0) return
+  
+    const selectedIds = sportsDisciplines
+      .filter(discipline => pendingSportsDisciplineIds.includes(discipline.id))
+      .map(discipline => discipline.id.toString())
+  
+    updateFormState("sportsDisciplineSelected", selectedIds)
+  
+    setPendingSportsDisciplineIds(null) // セット後クリア
+  }, [pendingSportsDisciplineIds, sportsDisciplines])
+
+  const updateFormState = (field: string, value: unknown) => {
+    setFormState(prev => ({ ...prev, [field]: value }))
+  }
+
+  const handleSportsTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    updateFormState("sportsTypeSelected", e.target.value)
+    updateFormState("sportsDisciplineSelected", [])
+  }
+
+  const handleMultiSelectChange = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+    field: string
+  ) => {
+    const selectedIds = Array.from(e.target.selectedOptions).map(opt => opt.value)
+    updateFormState(field, selectedIds)
+  }
+
+  const handlePrefectureChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    updateFormState("prefectureSelected", e.target.value)
+  }
+
+  const handleInputChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    updateFormState(field, e.target.value)
+  }
+  
+  const handleSexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateFormState("sex", e.target.value)
+  }
+  
+  const formatSelectedNames = (selectedIds: string[], options: SelectOption[]) => {
+    if (selectedIds.length === 0) return null
+  
+    const selectedNames = options
+      .filter(option => selectedIds.includes(option.id.toString()))
+      .map(option => option.name)
+  
+    return (
+      <div className="mt-2 py-2 px-3 border-2 border-gray-200 rounded-lg bg-white text-gray-700">
+        {selectedNames.join(", ")}
+      </div>
+    )
+  }  
+  
+  const ErrorList = (errors: string[]) => {
+    if (errors.length === 0) return null
+
+    return (
+      <ul className="text-red-500 text-sm list-disc list-inside text-left md:pl-44 pl-12">
+        {errors.map((error, index) => (
+          <li key={index}>{error}</li>
+        ))}
+      </ul>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-center mt-32 md:mt-20">
+      <div className="w-full md:w-3/5 xl:w-2/5 shadow-gray-200 bg-sky-100 rounded-lg">
+        <h2 className="text-center mb-10 pt-10 font-bold text-3xl text-blue-600">チーム紹介編集</h2>
+        <ul className="space-y-4 text-left">
+          {/* 競技種別 */}
+          <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+            <div className="md:col-span-12 md:ml-2 md:mr-4">
+              <SelectField
+                name={EVENT_FIELDS.SPORTS_TYPE}
+                title="競技名"
+                value={formState.sportsTypeSelected}
+                options={sportsTypes}
+                onChange={handleSportsTypeChange}
+              />
+            </div>
+          </li>
+          
+          {/* 種目 */}
+          {sportsDisciplines.length > 0 && (
+            <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+              <div className="md:col-span-12 md:ml-2 md:mr-4">
+                <SelectField
+                  name={EVENT_FIELDS.SPORTS_DISCIPLINE}
+                  multiple
+                  title={<>種目<br />（複数可）</>}
+                  value={formState.sportsDisciplineSelected}
+                  options={sportsDisciplines}
+                  onChange={(e) => handleMultiSelectChange(e, "sportsDisciplineSelected")}
+                />
+                {formatSelectedNames(formState.sportsDisciplineSelected, sportsDisciplines)}
+              </div>
+            </li>
+          )}
+
+          {/* 都道府県 */}
+          <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+            <div className="md:col-span-12 md:ml-2 md:mr-4">
+              <SelectField
+                name={EVENT_FIELDS.PREFECTURE}
+                title="都道府県"
+                value={formState.prefectureSelected}
+                options={prefectures}
+                onChange={handlePrefectureChange}
+              />
+            </div>
+          </li>
+
+          {/* チーム名 */}
+          <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+            <div className="md:col-span-12 md:ml-2 md:mr-4">
+              <InputField
+                name={EVENT_FIELDS.NAME}
+                type="text"
+                title="チーム名"
+                placeholder="チーム名"
+                value={formState.name}
+                onChange={handleInputChange("name")}
+              />
+            </div>
+          </li>
+
+          {/* 活動地域 */}
+          <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+            <div className="md:col-span-12 md:ml-2 md:mr-4">
+              <TextareaField
+                name={EVENT_FIELDS.AREA}
+                title="活動地域"
+                placeholder="活動地域"
+                value={formState.area}
+                rows={4}
+                onChange={handleInputChange("area")}
+              />
+            </div>
+          </li>
+
+          {/* 性別 */}
+          <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+            <div className="md:col-span-12 md:ml-2 md:mr-4">
+              <RadioGroupField
+                name={EVENT_FIELDS.SEX}
+                title="性別"
+                options={[
+                  { title: "男", value: "man" },
+                  { title: "女", value: "woman" },
+                  { title: "男女", value: "mix" },
+                  { title: "混合", value: "man_and_woman" }
+                ]}
+                selected={formState.sex}
+                onChange={handleSexChange}
+              />
+            </div>
+          </li>
+
+          {/* 対象年齢 */}
+          <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+            <div className="md:col-span-12 md:ml-2 md:mr-4">
+              <SelectField
+                name={EVENT_FIELDS.TARGET_AGE}
+                multiple
+                title={<>対象年齢<br />（複数可）</>}
+                value={formState.targetAgeSelected}
+                options={targetAges}
+                onChange={(e) => handleMultiSelectChange(e, "targetAgeSelected")}
+              />
+              {formatSelectedNames(formState.targetAgeSelected, targetAges)}
+            </div>
+          </li>
+
+          {/* 活動実績 */}
+          <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+            <div className="md:col-span-12 md:ml-2 md:mr-4">
+              <TextareaField
+                name={EVENT_FIELDS.TRACK_RECORD}
+                title="活動実績"
+                placeholder="活動実績"
+                value={formState.trackRecord}
+                rows={5}
+                onChange={handleInputChange("trackRecord")}
+              />
+            </div>
+          </li>
+
+          {/* その他 */}
+          <li className="md:grid md:grid-cols-12 md:gap-4 md:items-center">
+            <div className="md:col-span-12 md:ml-2 md:mr-4">
+              <TextareaField
+                name={EVENT_FIELDS.OTHER_BODY}
+                title="その他"
+                placeholder="その他"
+                value={formState.otherBody}
+                rows={5}
+                onChange={handleInputChange("otherBody")}
+              />
+            </div>
+          </li>
+        </ul>
+        {ErrorList([...initialErrors, ...sportsDisciplineErrors, ...errors])}
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/teamPages/TeamProfileEditPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileEditPage.tsx
@@ -70,8 +70,8 @@ export default function TeamProfileEditPage() {
         if (!teamData) return
 
         setTeamFormState(teamData)
-        setSelectedSportsType(teamData.sports_type_id)
-        setSelectedTargetAge(targetAgeIds)
+        setSportsTypeSelected(teamData.sports_type_id?.toString() ?? "")
+        setTargetAgeSelected((targetAgeIds || []).map(String))
         setPendingSportsDisciplineIds(sportsDisciplineIds)
         setFetchedId(teamId)
       })
@@ -97,18 +97,6 @@ export default function TeamProfileEditPage() {
     setOtherBody(teamData.other_body || "")
   }
 
-  const setSelectedSportsType = (selectSportsTypeId?: number) => {
-    if (selectSportsTypeId) {
-      setSportsTypeSelected(selectSportsTypeId.toString())
-    }
-  }
-
-  const setSelectedTargetAge = (targetAgeIds?: number[]) => {
-    if (targetAgeIds && targetAgeIds.length > 0) {
-      setTargetAgeSelected(targetAgeIds.map(id => id.toString()))
-    }
-  }
-
   useEffect(() => {
     if (!pendingSportsDisciplineIds || sportsDisciplines.length === 0) return
   
@@ -120,7 +108,7 @@ export default function TeamProfileEditPage() {
     setPendingSportsDisciplineIds(null) // セット後クリア
   }, [pendingSportsDisciplineIds, sportsDisciplines])
 
-  const handleMultiSelectChange = (
+  const handleSelectedValuesChange = (
     e: React.ChangeEvent<HTMLSelectElement>,
     setter: React.Dispatch<React.SetStateAction<string[]>>
   ) => {
@@ -190,7 +178,7 @@ export default function TeamProfileEditPage() {
                   title={<>種目<br />（複数可）</>}
                   value={sportsDisciplineSelected}
                   options={sportsDisciplines}
-                  onChange={(e) => handleMultiSelectChange(e, setSportsDisciplineSelected)}
+                  onChange={(e) => handleSelectedValuesChange(e, setSportsDisciplineSelected)}
                 />
                 {formatSelectedNames(sportsDisciplineSelected, sportsDisciplines)}
               </div>
@@ -265,7 +253,7 @@ export default function TeamProfileEditPage() {
                 title={<>対象年齢<br />（複数可）</>}
                 value={targetAgeSelected}
                 options={targetAges}
-                onChange={(e) => handleMultiSelectChange(e, setTargetAgeSelected)}
+                onChange={(e) => handleSelectedValuesChange(e, setTargetAgeSelected)}
               />
               {formatSelectedNames(targetAgeSelected, targetAges)}
             </div>

--- a/frontend-react/src/pages/teamPages/TeamProfileEditPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileEditPage.tsx
@@ -36,17 +36,15 @@ export default function TeamProfileEditPage() {
     OTHER_BODY: "teamOtherBody"
   }
 
-  const [formState, setFormState] = useState({
-    sportsTypeSelected: "",
-    sportsDisciplineSelected: [],
-    targetAgeSelected: [],
-    prefectureSelected: "",
-    name: "",
-    area: "",
-    sex: "",
-    trackRecord: "",
-    otherBody: ""
-  })
+  const [sportsTypeSelected, setSportsTypeSelected] = useState("")
+  const [sportsDisciplineSelected, setSportsDisciplineSelected] = useState<string[]>([])
+  const [targetAgeSelected, setTargetAgeSelected] = useState<string[]>([])
+  const [prefectureSelected, setPrefectureSelected] = useState("")
+  const [name, setName] = useState("")
+  const [area, setArea] = useState("")
+  const [sex, setSex] = useState("")
+  const [trackRecord, setTrackRecord] = useState("")
+  const [otherBody, setOtherBody] = useState("")
   
   const [errors, setErrors] = useState<string[]>([])
   const [fetchedId, setFetchedId] = useState<string | null>(null)
@@ -59,7 +57,7 @@ export default function TeamProfileEditPage() {
     errors: initialErrors
   } = useInitialFormData()
 
-  const { sportsDisciplines, errors: sportsDisciplineErrors } = useFetchDisciplines(formState.sportsTypeSelected)
+  const { sportsDisciplines, errors: sportsDisciplineErrors } = useFetchDisciplines(sportsTypeSelected)
 
   useEffect(() => {
     setErrors([])
@@ -68,19 +66,19 @@ export default function TeamProfileEditPage() {
     if (!teamId) return
 
     fetchTeamData(teamId)
-    .then(({ teamData, sportsDisciplineIds, targetAgeIds }) => {
-      if (!teamData) return
+      .then(({ teamData, sportsDisciplineIds, targetAgeIds }) => {
+        if (!teamData) return
 
-      setTeamFormState(teamData)
-      setSelectedSportsType(teamData.sports_type_id)
-      setSelectedTargetAge(targetAgeIds)
-      setPendingSportsDisciplineIds(sportsDisciplineIds)
-      setFetchedId(teamId)
-    })
-    .catch(() => {
-      setErrors(["チーム紹介を表示できませんでした。"])
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        setTeamFormState(teamData)
+        setSelectedSportsType(teamData.sports_type_id)
+        setSelectedTargetAge(targetAgeIds)
+        setPendingSportsDisciplineIds(sportsDisciplineIds)
+        setFetchedId(teamId)
+      })
+      .catch(() => {
+        setErrors(["チーム紹介を表示できませんでした。"])
+      })
+      // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamId, sportsTypes, prefectures, targetAges])
 
   const fetchTeamData = async (teamId: string) => {
@@ -91,27 +89,23 @@ export default function TeamProfileEditPage() {
   }  
 
   const setTeamFormState = (teamData: TeamData) => {
-    setFormState(prev => ({
-      ...prev,
-      name: teamData.name || "",
-      area: teamData.area || "",
-      sex: teamData.sex || "",
-      prefectureSelected: teamData.prefecture_id ? teamData.prefecture_id.toString() : "",
-      trackRecord: teamData.track_record || "",
-      otherBody: teamData.other_body || ""
-    }))
-  }  
+    setName(teamData.name || "")
+    setArea(teamData.area || "")
+    setSex(teamData.sex || "")
+    setPrefectureSelected(teamData.prefecture_id ? teamData.prefecture_id.toString() : "")
+    setTrackRecord(teamData.track_record || "")
+    setOtherBody(teamData.other_body || "")
+  }
 
   const setSelectedSportsType = (selectSportsTypeId?: number) => {
     if (selectSportsTypeId) {
-      updateFormState("sportsTypeSelected", selectSportsTypeId.toString())
+      setSportsTypeSelected(selectSportsTypeId.toString())
     }
   }
 
   const setSelectedTargetAge = (targetAgeIds?: number[]) => {
     if (targetAgeIds && targetAgeIds.length > 0) {
-      const selectedIds = targetAgeIds.map(targetAgeId => targetAgeId.toString())
-      updateFormState("targetAgeSelected", selectedIds)
+      setTargetAgeSelected(targetAgeIds.map(id => id.toString()))
     }
   }
 
@@ -122,46 +116,29 @@ export default function TeamProfileEditPage() {
       .filter(discipline => pendingSportsDisciplineIds.includes(discipline.id))
       .map(discipline => discipline.id.toString())
   
-    updateFormState("sportsDisciplineSelected", selectedIds)
-  
+    setSportsDisciplineSelected(selectedIds)
     setPendingSportsDisciplineIds(null) // セット後クリア
   }, [pendingSportsDisciplineIds, sportsDisciplines])
 
-  const updateFormState = (field: string, value: unknown) => {
-    setFormState(prev => ({ ...prev, [field]: value }))
-  }
-
-  const handleSportsTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    updateFormState("sportsTypeSelected", e.target.value)
-    updateFormState("sportsDisciplineSelected", [])
-  }
-
   const handleMultiSelectChange = (
     e: React.ChangeEvent<HTMLSelectElement>,
-    field: string
+    setter: React.Dispatch<React.SetStateAction<string[]>>
   ) => {
-    const selectedIds = Array.from(e.target.selectedOptions).map(opt => opt.value)
-    updateFormState(field, selectedIds)
+    const selected = Array.from(e.target.selectedOptions).map(opt => opt.value)
+    setter(selected)
   }
 
-  const handlePrefectureChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    updateFormState("prefectureSelected", e.target.value)
-  }
-
-  const handleInputChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    updateFormState(field, e.target.value)
-  }
-  
-  const handleSexChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    updateFormState("sex", e.target.value)
+  const handleTextChange = (
+    setter: React.Dispatch<React.SetStateAction<string>>
+  ) => {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setter(e.target.value)
+    }
   }
   
   const formatSelectedNames = (selectedIds: string[], options: SelectOption[]) => {
     if (selectedIds.length === 0) return null
-  
-    const selectedNames = options
-      .filter(option => selectedIds.includes(option.id.toString()))
-      .map(option => option.name)
+    const selectedNames = options.filter(o => selectedIds.includes(o.id.toString())).map(o => o.name)
   
     return (
       <div className="mt-2 py-2 px-3 border-2 border-gray-200 rounded-lg bg-white text-gray-700">
@@ -193,9 +170,12 @@ export default function TeamProfileEditPage() {
               <SelectField
                 name={EVENT_FIELDS.SPORTS_TYPE}
                 title="競技名"
-                value={formState.sportsTypeSelected}
+                value={sportsTypeSelected}
                 options={sportsTypes}
-                onChange={handleSportsTypeChange}
+                onChange={(e) => {
+                  setSportsTypeSelected(e.target.value)
+                  setSportsDisciplineSelected([])
+                }}
               />
             </div>
           </li>
@@ -208,11 +188,11 @@ export default function TeamProfileEditPage() {
                   name={EVENT_FIELDS.SPORTS_DISCIPLINE}
                   multiple
                   title={<>種目<br />（複数可）</>}
-                  value={formState.sportsDisciplineSelected}
+                  value={sportsDisciplineSelected}
                   options={sportsDisciplines}
-                  onChange={(e) => handleMultiSelectChange(e, "sportsDisciplineSelected")}
+                  onChange={(e) => handleMultiSelectChange(e, setSportsDisciplineSelected)}
                 />
-                {formatSelectedNames(formState.sportsDisciplineSelected, sportsDisciplines)}
+                {formatSelectedNames(sportsDisciplineSelected, sportsDisciplines)}
               </div>
             </li>
           )}
@@ -223,9 +203,9 @@ export default function TeamProfileEditPage() {
               <SelectField
                 name={EVENT_FIELDS.PREFECTURE}
                 title="都道府県"
-                value={formState.prefectureSelected}
+                value={prefectureSelected}
                 options={prefectures}
-                onChange={handlePrefectureChange}
+                onChange={(e) => setPrefectureSelected(e.target.value)}
               />
             </div>
           </li>
@@ -238,8 +218,8 @@ export default function TeamProfileEditPage() {
                 type="text"
                 title="チーム名"
                 placeholder="チーム名"
-                value={formState.name}
-                onChange={handleInputChange("name")}
+                value={name}
+                onChange={handleTextChange(setName)}
               />
             </div>
           </li>
@@ -251,9 +231,9 @@ export default function TeamProfileEditPage() {
                 name={EVENT_FIELDS.AREA}
                 title="活動地域"
                 placeholder="活動地域"
-                value={formState.area}
+                value={area}
                 rows={4}
-                onChange={handleInputChange("area")}
+                onChange={handleTextChange(setArea)}
               />
             </div>
           </li>
@@ -270,8 +250,8 @@ export default function TeamProfileEditPage() {
                   { title: "男女", value: "mix" },
                   { title: "混合", value: "man_and_woman" }
                 ]}
-                selected={formState.sex}
-                onChange={handleSexChange}
+                selected={sex}
+                onChange={(e) => setSex(e.target.value)}
               />
             </div>
           </li>
@@ -283,11 +263,11 @@ export default function TeamProfileEditPage() {
                 name={EVENT_FIELDS.TARGET_AGE}
                 multiple
                 title={<>対象年齢<br />（複数可）</>}
-                value={formState.targetAgeSelected}
+                value={targetAgeSelected}
                 options={targetAges}
-                onChange={(e) => handleMultiSelectChange(e, "targetAgeSelected")}
+                onChange={(e) => handleMultiSelectChange(e, setTargetAgeSelected)}
               />
-              {formatSelectedNames(formState.targetAgeSelected, targetAges)}
+              {formatSelectedNames(targetAgeSelected, targetAges)}
             </div>
           </li>
 
@@ -298,9 +278,9 @@ export default function TeamProfileEditPage() {
                 name={EVENT_FIELDS.TRACK_RECORD}
                 title="活動実績"
                 placeholder="活動実績"
-                value={formState.trackRecord}
+                value={trackRecord}
                 rows={5}
-                onChange={handleInputChange("trackRecord")}
+                onChange={handleTextChange(setTrackRecord)}
               />
             </div>
           </li>
@@ -312,9 +292,9 @@ export default function TeamProfileEditPage() {
                 name={EVENT_FIELDS.OTHER_BODY}
                 title="その他"
                 placeholder="その他"
-                value={formState.otherBody}
+                value={otherBody}
                 rows={5}
-                onChange={handleInputChange("otherBody")}
+                onChange={handleTextChange(setOtherBody)}
               />
             </div>
           </li>

--- a/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileListPage.tsx
@@ -19,19 +19,25 @@ export default function TeamProfileList() {
   const fetchTeamProfile = async () => {
     try {
       setErrors([])
-      const res = await apiClient.get('/teams')
-      setTeams(res.data.data)
+      const TeamProfileRes = (await apiClient.get('/teams')).data.data
+      setTeams(TeamProfileRes)
     } catch {
       setErrors(["チーム名を表示できませんでした。"])
     }
   }
 
-  const editTeamProfile = () => {
-    console.log("チーム紹介編集画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  const editTeamProfile = (id: number) => {
+    navigate(`/team_profile_edit/${id}`)
   }
 
-  const deleteTeamProfile = () => {
-    console.log("チーム紹介削除は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+  const deleteTeamProfile = async (id: number) => {
+    setErrors([])
+    try {
+      const deleteTeamProfileRes = (await apiClient.delete(`/teams/${id}`)).data
+      setTeams(deleteTeamProfileRes)
+    } catch {
+      setErrors(["イベントを削除できませんでした。"])
+    }
   }
 
   const createTeamProfile = () => {
@@ -69,8 +75,8 @@ export default function TeamProfileList() {
               >
                 チーム名: {team.name}
                 <div className="flex justify-center mt-5">
-                  <Button variant="yellow" size="sm" className="my-4 md:mb-0 md:mr-4 mx-3" onClick={() => editTeamProfile()}>編集</Button>
-                  <Button variant="red" size="sm" className="my-4 md:mb-0 md:mr-4 mx-3" onClick={() => deleteTeamProfile()}>削除</Button>
+                  <Button variant="yellow" size="sm" className="my-4 md:mb-0 md:mr-4 mx-3" onClick={() => editTeamProfile(team.id)}>編集</Button>
+                  <Button variant="red" size="sm" className="my-4 md:mb-0 md:mr-4 mx-3" onClick={() => deleteTeamProfile(team.id)}>削除</Button>
                 </div>
               </div>
             ))}

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -15,6 +15,7 @@ import EventSettingListPage from "@/pages/eventPages/EventSettingListPage"
 import EventSettingEditPage from "@/pages/eventPages/EventSettingEditPage"
 import TeamProfileListPage from "@/pages/teamPages/TeamProfileListPage"
 import TeamProfilePage from "@/pages/teamPages/TeamProfilePage"
+import TeamProfileEditPage from "@/pages/teamPages/TeamProfileEditPage"
 import ChatRoomListPage from "@/pages/chatPage/ChatRoomListPage"
 import BasicSettingEditPage from "@/pages/BasicSettingEditPage"
 import UserProfilePage from "@/pages/UserProfilePage"
@@ -72,6 +73,7 @@ export default function AppRouter() {
           <Route path="/event_setting_edit/:id" element={<EventSettingEditPage />} />
           <Route path="/team_profile_list" element={<TeamProfileListPage />} />
           <Route path="/team_profile" element={<TeamProfilePage />} />
+          <Route path="/team_profile_edit/:id" element={<TeamProfileEditPage />} />
           <Route path="/chat_room_list" element={<ChatRoomListPage />} />
           <Route path="/basic_setting_edit" element={<BasicSettingEditPage />} />
           <Route path="/user_profile/:userId" element={<UserProfilePage />} />


### PR DESCRIPTION
### 概要
チーム紹介編集画面（TeamProfileEditPage.tsx）を新規で実装しました。
### 変更内容
- 競技名、種目、メールアドレス、都道府県、チーム名、活動地域、性別、対象年齢、活動実績、その他の編集フォーム
- アイコン画像のアップロード機能
- 入力値に対するバリデーション（例：名前2〜100文字、自己紹介1〜255文字）
- 文字数制限に応じた残り文字数のリアルタイム表示
- API通信失敗時のエラーメッセージ表示

close https://github.com/toshinori-m/stay_connect/issues/218