### PR TITLE
チーム紹介画面を新規作成

### DIFF
--- a/frontend-react/src/pages/UserProfilePage.tsx
+++ b/frontend-react/src/pages/UserProfilePage.tsx
@@ -49,12 +49,13 @@ export default function UserProfilePage() {
   ].filter(Boolean) as string[]
 
   // チーム紹介ページへ
-  const handleTeamIntroduction = (teamId: number) => {
+  const handleTeamIntroduction = async(teamId: number) => {
     if (!teamId) {
       setErrors(prev => [...prev, "チームIDが指定されていません。"])
       return
     }
-    console.log("チーム紹介画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+
+    navigate(`/team_profile_introduction/${teamId}`)
   }
 
   // チャットボタン表示条件

--- a/frontend-react/src/pages/teamPages/TeamProfileIntroductionPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileIntroductionPage.tsx
@@ -1,0 +1,247 @@
+import { useState, useEffect } from "react"
+import { useParams, useNavigate } from "react-router-dom"
+import { useApiClient } from "@/hooks/useApiClient"
+import useInitialFormData from "@/hooks/search/useInitialFormData"
+import useFetchDisciplines from "@/hooks/search/useFetchDisciplines"
+import Button from "@/components/ui/Button"
+import { SelectOption } from "@/types"
+
+interface TeamProfile {
+  id: string
+  name: string
+  sports_type_id: number
+  prefecture_id: number
+  area: string
+  sex: string
+  track_record: string
+  other_body: string
+  user_id: string
+}
+
+interface ValueLabelOption {
+  value: string
+  title: string
+}
+
+export default function TeamProfileIntroduction() {
+  const { id: TeamProfileId } = useParams<{ id: string }>()
+  const apiClient = useApiClient()
+  const navigate = useNavigate()
+
+  const [userId, setUserId] = useState("")
+  const [sportsTypeSelected, setSportsTypeSelected] = useState("")
+  const [sportsDisciplineSelected, setSportsDisciplineSelected] = useState<string[]>([])
+  const [targetAgeSelected, setTargetAgeSelected] = useState<string[]>([])
+  const [prefectureSelected, setPrefectureSelected] = useState("")
+  const [name, setName] = useState("")
+  const [area, setArea] = useState("")
+  const [sex, setSex] = useState("")
+  const [trackRecord, setTrackRecord] = useState("")
+  const [otherBody, setOtherBody] = useState("")
+
+  const [errors, setErrors] = useState<string[]>([])
+  const [fetchedTeamProfileId, setFetchedTeamProfileId] = useState<string | null>(null)
+  const [pendingSportsDisciplineIds, setPendingSportsDisciplineIds] = useState<number[] | null>(null)
+
+  const {
+    sportsTypes,
+    prefectures,
+    targetAges,
+    errors: initialErrors
+  } = useInitialFormData()
+
+  const { sportsDisciplines, errors: sportsDisciplineErrors } = useFetchDisciplines(sportsTypeSelected)
+
+  useEffect(() => {
+    setErrors([])
+    if (fetchedTeamProfileId === TeamProfileId) return
+    if (sportsTypes.length === 0 || prefectures.length === 0 || targetAges.length === 0) return
+    if (!TeamProfileId) return
+
+    fetchTeamProfile(TeamProfileId)
+      .then(({ TeamProfileData, sportsDisciplineIds, targetAgeIds }) => {
+        if (!TeamProfileData) return
+
+        applyTeamProfileData(TeamProfileData)
+        setSelectedSportsType(TeamProfileData.sports_type_id?.toString() ?? "")
+        setSelectedTargetAges((targetAgeIds || []).map(String))
+        setPendingSportsDisciplineIds(sportsDisciplineIds)
+        setFetchedTeamProfileId(TeamProfileId)
+      })
+      .catch(() => {
+        setErrors(["チーム紹介を表示できませんでした。"])
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [TeamProfileId, sportsTypes, prefectures, targetAges])
+
+  // チームプロフィール情報を取得
+  const fetchTeamProfile = async (TeamProfileId: string) => {
+      const TeamProfileData = (await apiClient.get(`/teams/${TeamProfileId}`)).data.data
+
+      const sportsDisciplineIds = TeamProfileData.sports_disciplines
+      const targetAgeIds = TeamProfileData.target_ages
+      return { TeamProfileData, sportsDisciplineIds, targetAgeIds }
+  }
+
+  const applyTeamProfileData = (teamProfileData: TeamProfile) => {
+    setName(teamProfileData.name || "")
+    setArea(teamProfileData.area || "")
+    setSex(teamProfileData.sex || "")
+    setPrefectureSelected(teamProfileData.prefecture_id ? teamProfileData.prefecture_id.toString() : "")
+    setTrackRecord(teamProfileData.track_record || "")
+    setOtherBody(teamProfileData.other_body || "")
+    setUserId(teamProfileData.user_id || "")
+  }
+
+  const setSelectedSportsType = (selectSportsTypeId?: number) => {
+    if (selectSportsTypeId) {
+      setSportsTypeSelected(selectSportsTypeId.toString())
+    }
+  }
+
+  const setSelectedTargetAges = (targetAgeIds?: number[]) => {
+    if (targetAgeIds && targetAgeIds.length > 0) {
+      setTargetAgeSelected(targetAgeIds.map(id => id.toString()))
+    }
+  }
+
+  useEffect(() => {
+    if (!pendingSportsDisciplineIds || sportsDisciplines.length === 0) return
+  
+    const selectedIds = sportsDisciplines
+      .filter(discipline => pendingSportsDisciplineIds.includes(discipline.id))
+      .map(discipline => discipline.id.toString())
+  
+    setSportsDisciplineSelected(selectedIds)
+    setPendingSportsDisciplineIds(null) // セット後クリア
+  }, [pendingSportsDisciplineIds, sportsDisciplines])
+
+  // 代表紹介ページへ
+  const handleUserProfile = async(userId: string) => {
+    if (!userId) {
+      setErrors(prev => [...prev, "チームIDが指定されていません。"])
+      return
+    }
+
+    navigate(`/user_profile/${userId}`)
+  }
+
+  const mapSelectedValueToTitle = (
+    selectedValue: string,
+    options: ValueLabelOption[]
+  ): string => {
+    return options.find((option) => option.title === selectedValue)?.value || ""
+  }
+  
+  const sexOptions: ValueLabelOption[]= [
+    { value: "男", title: "man" },
+    { value: "女", title: "woman" },
+    { value: "男女", title: "mix" },
+    { value: "混合", title: "man_and_woman" }
+  ]
+
+  const mapSelectedIdToName = (
+    selectedId: string,
+    options: SelectOption[]
+  ): string => {
+    return options.find((option) => option.id.toString() === selectedId)?.name || ""
+  }
+  
+  const selectedSportsTypeName = mapSelectedIdToName(sportsTypeSelected, sportsTypes)
+  const selectedPrefectureName = mapSelectedIdToName(prefectureSelected, prefectures)
+
+  const mapSelectedIdsToNames = (
+    selectedIds: string[],
+    options: SelectOption[]
+  ): string[] => {
+    return options
+      .filter((option) => selectedIds.includes(option.id.toString()))
+      .map((option) => option.name)
+  }
+
+  const selectedSportsDisciplineNames = mapSelectedIdsToNames(sportsDisciplineSelected, sportsDisciplines)
+  const selectedTargetAgeNames = mapSelectedIdsToNames(targetAgeSelected, targetAges)
+
+  const ErrorList = (errors: string[]) => {
+    if (errors.length === 0) return null
+
+    return (
+      <ul className="text-red-500 text-sm list-disc list-inside text-left md:pl-44 pl-12">
+        {errors.map((error, index) => (
+          <li key={index}>{error}</li>
+        ))}
+      </ul>
+    )
+  }
+
+  const labelClass = "font-semibold text-blue-600"
+  const infoTagClass =
+  "bg-green-100 text-green-800 text-sm font-medium px-3 py-1 rounded-full border border-green-800 inline-block"
+
+  return (
+    <div className="mt-40 md:mt-20 max-w-2xl mx-auto p-6 bg-sky-100 shadow-lg rounded-lg break-words">
+      {/* エラーメッセージの表示 */}
+      {ErrorList([...initialErrors, ...sportsDisciplineErrors, ...errors])}
+  
+      {/* 代表紹介ボタン */}
+      <div className="text-right mb-4">
+        <Button type="submit" variant="primary" size="sm" onClick={() => handleUserProfile(userId)}>
+          代表紹介
+        </Button>
+      </div>
+  
+      <ul className="space-y-4 text-left">
+        <li>
+          <span className={labelClass}>チーム名: </span>
+          <span className={infoTagClass}>{name}</span>
+        </li>
+        <li>
+          <span className={labelClass}>競技: </span>
+          <span className={infoTagClass}>{selectedSportsTypeName}</span>
+        </li>
+        {selectedSportsDisciplineNames.length > 0 && (
+          <li className="flex items-center gap-2 flex-wrap">
+            <span className={labelClass}>種目: </span>
+            <div className="flex flex-wrap gap-2 mt-1">
+              {selectedSportsDisciplineNames.map((name, index) => (
+                <span key={index} className={infoTagClass}>
+                  {name}
+                </span>
+              ))}
+            </div>
+          </li>
+        )}
+        <li>
+          <span className={labelClass}>活動都道府県: </span>
+          <span className={infoTagClass}>{selectedPrefectureName}</span>
+        </li>
+        <li>
+          <span className={labelClass}>活動地域: </span>
+          <span className={infoTagClass}>{area}</span>
+        </li>
+        <li>
+          <span className={labelClass}>性別: </span>
+          <span className={infoTagClass}>{mapSelectedValueToTitle(sex, sexOptions)}</span>
+        </li>
+        <li className="flex items-center gap-2 flex-wrap">
+          <span className={labelClass}>対象年齢: </span>
+          <span className="flex flex-wrap gap-2 mt-1">
+            {selectedTargetAgeNames.map((name, index) => (
+              <span key={index} className={infoTagClass}>
+                {name}
+              </span>
+            ))}
+          </span>
+        </li>
+        <li>
+          <span className={labelClass}>活動実績: </span>
+          <span className={infoTagClass}>{trackRecord}</span>
+        </li>
+        <li>
+          <span className={labelClass}>チームPR: </span>
+          <span className={infoTagClass}>{otherBody}</span>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/teamPages/TeamProfileIntroductionPage.tsx
+++ b/frontend-react/src/pages/teamPages/TeamProfileIntroductionPage.tsx
@@ -6,18 +6,6 @@ import useFetchDisciplines from "@/hooks/search/useFetchDisciplines"
 import Button from "@/components/ui/Button"
 import { SelectOption } from "@/types"
 
-interface TeamProfile {
-  id: string
-  name: string
-  sports_type_id: number
-  prefecture_id: number
-  area: string
-  sex: string
-  track_record: string
-  other_body: string
-  user_id: string
-}
-
 interface ValueLabelOption {
   value: string
   title: string
@@ -42,6 +30,13 @@ export default function TeamProfileIntroduction() {
   const [errors, setErrors] = useState<string[]>([])
   const [fetchedTeamProfileId, setFetchedTeamProfileId] = useState<string | null>(null)
   const [pendingSportsDisciplineIds, setPendingSportsDisciplineIds] = useState<number[] | null>(null)
+  
+  const SEX_OPTIONS: ValueLabelOption[] = [
+    { value: "男", title: "man" },
+    { value: "女", title: "woman" },
+    { value: "男女", title: "mix" },
+    { value: "混合", title: "man_and_woman" }
+  ]
 
   const {
     sportsTypes,
@@ -62,9 +57,18 @@ export default function TeamProfileIntroduction() {
       .then(({ TeamProfileData, sportsDisciplineIds, targetAgeIds }) => {
         if (!TeamProfileData) return
 
-        applyTeamProfileData(TeamProfileData)
-        setSelectedSportsType(TeamProfileData.sports_type_id?.toString() ?? "")
-        setSelectedTargetAges((targetAgeIds || []).map(String))
+        // プロフィール関連のデータをセット
+        setName(TeamProfileData.name || "")
+        setArea(TeamProfileData.area || "")
+        setSex(TeamProfileData.sex || "")
+        setPrefectureSelected(TeamProfileData.prefecture_id ? TeamProfileData.prefecture_id.toString() : "")
+        setTrackRecord(TeamProfileData.track_record || "")
+        setOtherBody(TeamProfileData.other_body || "")
+        setUserId(TeamProfileData.user_id || "")
+
+        // 関連 ID をセット
+        setSportsTypeSelected(TeamProfileData.sports_type_id?.toString() ?? "")
+        setTargetAgeSelected((targetAgeIds || []).map(String))
         setPendingSportsDisciplineIds(sportsDisciplineIds)
         setFetchedTeamProfileId(TeamProfileId)
       })
@@ -81,28 +85,6 @@ export default function TeamProfileIntroduction() {
       const sportsDisciplineIds = TeamProfileData.sports_disciplines
       const targetAgeIds = TeamProfileData.target_ages
       return { TeamProfileData, sportsDisciplineIds, targetAgeIds }
-  }
-
-  const applyTeamProfileData = (teamProfileData: TeamProfile) => {
-    setName(teamProfileData.name || "")
-    setArea(teamProfileData.area || "")
-    setSex(teamProfileData.sex || "")
-    setPrefectureSelected(teamProfileData.prefecture_id ? teamProfileData.prefecture_id.toString() : "")
-    setTrackRecord(teamProfileData.track_record || "")
-    setOtherBody(teamProfileData.other_body || "")
-    setUserId(teamProfileData.user_id || "")
-  }
-
-  const setSelectedSportsType = (selectSportsTypeId?: number) => {
-    if (selectSportsTypeId) {
-      setSportsTypeSelected(selectSportsTypeId.toString())
-    }
-  }
-
-  const setSelectedTargetAges = (targetAgeIds?: number[]) => {
-    if (targetAgeIds && targetAgeIds.length > 0) {
-      setTargetAgeSelected(targetAgeIds.map(id => id.toString()))
-    }
   }
 
   useEffect(() => {
@@ -126,31 +108,24 @@ export default function TeamProfileIntroduction() {
     navigate(`/user_profile/${userId}`)
   }
 
-  const mapSelectedValueToTitle = (
+  const findValueByTitle = (
     selectedValue: string,
     options: ValueLabelOption[]
   ): string => {
     return options.find((option) => option.title === selectedValue)?.value || ""
   }
-  
-  const sexOptions: ValueLabelOption[]= [
-    { value: "男", title: "man" },
-    { value: "女", title: "woman" },
-    { value: "男女", title: "mix" },
-    { value: "混合", title: "man_and_woman" }
-  ]
 
-  const mapSelectedIdToName = (
+  const findNameById = (
     selectedId: string,
     options: SelectOption[]
   ): string => {
     return options.find((option) => option.id.toString() === selectedId)?.name || ""
   }
   
-  const selectedSportsTypeName = mapSelectedIdToName(sportsTypeSelected, sportsTypes)
-  const selectedPrefectureName = mapSelectedIdToName(prefectureSelected, prefectures)
+  const selectedSportsTypeName = findNameById(sportsTypeSelected, sportsTypes)
+  const selectedPrefectureName = findNameById(prefectureSelected, prefectures)
 
-  const mapSelectedIdsToNames = (
+  const findNamesByIds = (
     selectedIds: string[],
     options: SelectOption[]
   ): string[] => {
@@ -159,8 +134,8 @@ export default function TeamProfileIntroduction() {
       .map((option) => option.name)
   }
 
-  const selectedSportsDisciplineNames = mapSelectedIdsToNames(sportsDisciplineSelected, sportsDisciplines)
-  const selectedTargetAgeNames = mapSelectedIdsToNames(targetAgeSelected, targetAges)
+  const selectedSportsDisciplineNames = findNamesByIds(sportsDisciplineSelected, sportsDisciplines)
+  const selectedTargetAgeNames = findNamesByIds(targetAgeSelected, targetAges)
 
   const ErrorList = (errors: string[]) => {
     if (errors.length === 0) return null
@@ -221,7 +196,7 @@ export default function TeamProfileIntroduction() {
         </li>
         <li>
           <span className={labelClass}>性別: </span>
-          <span className={infoTagClass}>{mapSelectedValueToTitle(sex, sexOptions)}</span>
+          <span className={infoTagClass}>{findValueByTitle(sex, SEX_OPTIONS)}</span>
         </li>
         <li className="flex items-center gap-2 flex-wrap">
           <span className={labelClass}>対象年齢: </span>

--- a/frontend-react/src/router/index.tsx
+++ b/frontend-react/src/router/index.tsx
@@ -18,6 +18,7 @@ import EventSettingEditPage from "@/pages/eventPages/EventSettingEditPage"
 import TeamProfileListPage from "@/pages/teamPages/TeamProfileListPage"
 import TeamProfilePage from "@/pages/teamPages/TeamProfilePage"
 import TeamProfileEditPage from "@/pages/teamPages/TeamProfileEditPage"
+import TeamProfileIntroductionPage from "@/pages/teamPages/TeamProfileIntroductionPage"
 import BasicSettingEditPage from "@/pages/BasicSettingEditPage"
 import UserProfilePage from "@/pages/UserProfilePage"
 
@@ -77,6 +78,7 @@ export default function AppRouter() {
           <Route path="/team_profile_list" element={<TeamProfileListPage />} />
           <Route path="/team_profile" element={<TeamProfilePage />} />
           <Route path="/team_profile_edit/:id" element={<TeamProfileEditPage />} />
+          <Route path="/team_profile_introduction/:id" element={<TeamProfileIntroductionPage />} />
           <Route path="/basic_setting_edit" element={<BasicSettingEditPage />} />
           <Route path="/user_profile/:userId" element={<UserProfilePage />} />
         </Route>


### PR DESCRIPTION
### 概要
- チームプロフィール詳細を表示する画面 （TeamProfileIntroductionPage） を新規作成しました。
### 変更内容
- 該当ユーザーの情報（team name, area, sex, disciplines など）の一覧を取得・表示。
- API取得時のエラー表示機能を実装。


close https://github.com/toshinori-m/stay_connect/issues/233