### PR TITLE
イベント詳細取得時の不要なリクエストを削減しパフォーマンスを改善

### DIFF
--- a/backend/app/controllers/recruitments_controller.rb
+++ b/backend/app/controllers/recruitments_controller.rb
@@ -25,7 +25,9 @@ class RecruitmentsController < ApplicationController
   end
 
   def show
-    @recruitment = Recruitment.find(params[:id])
+    @recruitment = Recruitment
+      .preload(:sports_type, :prefecture, :sports_disciplines, :target_ages)
+      .find(params[:id])
   end
 
   def destroy

--- a/backend/app/controllers/recruitments_controller.rb
+++ b/backend/app/controllers/recruitments_controller.rb
@@ -26,7 +26,7 @@ class RecruitmentsController < ApplicationController
 
   def show
     @recruitment = Recruitment
-      .preload(:sports_type, :prefecture, :sports_disciplines, :target_ages)
+      .preload(:sports_disciplines, :target_ages)
       .find(params[:id])
   end
 

--- a/backend/app/views/recruitments/show.json.jbuilder
+++ b/backend/app/views/recruitments/show.json.jbuilder
@@ -11,7 +11,9 @@ json.data do
   json.purpose_body @recruitment.purpose_body
   json.other_body @recruitment.other_body
   json.sports_type_id @recruitment.sports_type_id
+  json.sports_type_name @recruitment.sports_type&.name
   json.prefecture_id @recruitment.prefecture_id
+  json.prefecture_name @recruitment.prefecture&.name
 
   json.sports_disciplines do
     json.array! @recruitment.sports_disciplines, :id, :name

--- a/frontend-react/src/pages/eventPages/EventPage.tsx
+++ b/frontend-react/src/pages/eventPages/EventPage.tsx
@@ -2,17 +2,16 @@ import { useState, useEffect } from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import { useApiClient } from "@/hooks/useApiClient"
 import { SelectOption } from "@/types"
-import useInitialFormData from "@/hooks/search/useInitialFormData"
 import Button from "@/components/ui/Button"
 
 interface EventDetails {
   name: string
   image: string
   user_id: number
-  sports_type_id: number
+  sports_type_name: string
   sports_disciplines: SelectOption[]
   target_ages: SelectOption[]
-  prefecture_id: number
+  prefecture_name: string
   area: string
   purpose_body: string
   start_date: string
@@ -22,67 +21,66 @@ interface EventDetails {
   other_body: string
 }
 
+interface ValueLabelOption {
+  value: string
+  title: string
+}
+
 export default function EventPage() {
   const apiClient = useApiClient()
   const navigate = useNavigate()
   const [eventDetails, setEventDetails] = useState<EventDetails | null>(null)
   const [fetchedEventId, setFetchedEventId] = useState<string | null>(null)
-  const [sportsType, setSportsType] = useState("")
-  const [prefecture, setPrefecture] = useState("")
-  const [errors, setErrors] = useState<string[]>([])
+  const [error, setError] = useState("")
   const { id: eventId } = useParams()
 
-  const formatOptionNames = (options?: { name: string }[] | null): string => {
+  const SEX_OPTIONS: ValueLabelOption[] = [
+    { value: "男", title: "man" },
+    { value: "女", title: "woman" },
+    { value: "男女", title: "mix" },
+    { value: "混合", title: "man_and_woman" }
+  ]
+
+  const formatOptionNames = (options?: SelectOption[]): string => {
     return options?.length ? options.map(opt => opt.name).join(", ") : ""
   }
 
   const sportsDisciplinesNames = () => formatOptionNames(eventDetails?.sports_disciplines)
   const targetAgesNames = () => formatOptionNames(eventDetails?.target_ages)
 
-  const {
-    sportsTypes,
-    prefectures,
-    errors: initialErrors
-  } = useInitialFormData()
-
   useEffect(() => {
-    setErrors([])
+    setError("")
 
     if (!eventId || fetchedEventId === eventId) return
-    if (sportsTypes.length === 0 || prefectures.length === 0 ) return
 
     fetchEventDetails(eventId)
       .then(eventData => {
         setEventDetails(eventData)
         setFetchedEventId(eventId)
-        setSportsType(eventData.sports_type_id?.toString() ?? "")
-        setPrefecture(eventData.prefecture_id?.toString() ?? "")
       })
       .catch(() => {
-        setErrors(["基本設定を表示できませんでした。"])
+        setError("基本設定を表示できませんでした。")
       })
       // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [eventId, sportsTypes, prefectures])
+  }, [eventId])
 
   const fetchEventDetails = async (eventId: string) => {
     const eventData = (await apiClient.get(`/recruitments/${eventId}`)).data.data
     return eventData
   }
 
-  const mapSelectedIdToName = (
-    selectedId: string,
-    options: SelectOption[]
-  ): string => {
-    return options.find((option) => option.id.toString() === selectedId)?.name || ""
-  }
-  
-  const selectedSportsTypeName = mapSelectedIdToName(sportsType, sportsTypes)
-  const selectedPrefectureName = mapSelectedIdToName(prefecture, prefectures)
-
   const handleUserProfileClick = () => {
     if (eventDetails?.user_id) {
       navigate(`/user_profile/${eventDetails.user_id}`)
     }
+  }
+
+  const findValueByTitle = (
+    options: { value: string; title: string }[],
+    title: string
+  ): string => {
+    const matched = options.find(option => option.title === title)
+    return matched ? matched.value : "未設定"
   }
 
   const TitleAndValue = ({ title, children }: { title: string; children: React.ReactNode }) => (
@@ -91,28 +89,26 @@ export default function EventPage() {
     </p>
   )
 
-  if (!eventDetails) return
+  const Error = (error: string) => {
+    if (error.length === 0) return null
   
-  const ErrorList = (errors: string[]) => {
-    if (errors.length === 0) return null
-
     return (
-      <ul className="text-red-500 text-sm list-disc list-inside text-left md:pl-44 pl-12">
-        {errors.map((error, index) => (
-          <li key={index}>{error}</li>
-        ))}
-      </ul>
+      <p className="text-red-500 text-sm text-left md:pl-44 pl-12">
+        {error}
+      </p>
     )
-  }
+  }  
 
   return (
     <div className="mt-40 md:mt-20 max-w-2xl mx-auto p-6 bg-sky-100 shadow-lg rounded-lg break-words">
       <h1 className="text-2xl font-light mb-4">
         <span className="font-bold mr-3 text-blue-600">イベント名:</span>
-        {eventDetails.name}
+        {eventDetails?.name ?? "未設定"}
       </h1>
-      {eventDetails.image && (
+      {eventDetails?.image ? (
         <img src={eventDetails.image} alt="Event Image" className="w-full h-auto mb-4" />
+      ) : (
+        <p className="text-gray-500 text-sm mb-4">画像は未設定</p>
       )}
       <div className="text-right">
         <Button type="submit" variant="primary" size="sm" className="mr-4" onClick={() => handleUserProfileClick()}>
@@ -120,22 +116,22 @@ export default function EventPage() {
         </Button>
       </div>
       {/* エラーメッセージの表示 */}
-      {ErrorList([...initialErrors, ...errors])}
-      <TitleAndValue title="競技">{selectedSportsTypeName}</TitleAndValue>
+      {Error(error)}
+      <TitleAndValue title="競技">{eventDetails?.sports_type_name ?? "未設定"}</TitleAndValue>
 
-      {eventDetails.sports_disciplines?.length > 0 && (
+      {eventDetails?.sports_disciplines && eventDetails.sports_disciplines.length > 0 && (
         <TitleAndValue title="種目">{sportsDisciplinesNames()}</TitleAndValue>
       )}
 
-      <TitleAndValue title="都道府県">{selectedPrefectureName}</TitleAndValue>
-      <TitleAndValue title="開催地">{eventDetails.area}</TitleAndValue>
+      <TitleAndValue title="都道府県">{eventDetails?.prefecture_name ?? "未設定"}</TitleAndValue>
+      <TitleAndValue title="開催地">{eventDetails?.area ?? "未設定"}</TitleAndValue>
       <TitleAndValue title="対象年齢">{targetAgesNames()}</TitleAndValue>
-      <TitleAndValue title="目的">{eventDetails.purpose_body}</TitleAndValue>
-      <TitleAndValue title="開始日">{eventDetails.start_date}</TitleAndValue>
-      <TitleAndValue title="終了日">{eventDetails.end_date}</TitleAndValue>
-      <TitleAndValue title="性別">{eventDetails.sex}</TitleAndValue>
-      <TitleAndValue title="チーム数">{eventDetails.number}</TitleAndValue>
-      <TitleAndValue title="その他">{eventDetails.other_body}</TitleAndValue>
+      <TitleAndValue title="目的">{eventDetails?.purpose_body ?? "未設定"}</TitleAndValue>
+      <TitleAndValue title="開始日">{eventDetails?.start_date ?? "未設定"}</TitleAndValue>
+      <TitleAndValue title="終了日">{eventDetails?.end_date ?? "未設定"}</TitleAndValue>
+      <TitleAndValue title="性別">{findValueByTitle(SEX_OPTIONS, eventDetails?.sex ?? "未設定")}</TitleAndValue>
+      <TitleAndValue title="チーム数">{eventDetails?.number ?? "未設定"}</TitleAndValue>
+      <TitleAndValue title="その他">{eventDetails?.other_body ?? "未設定"}</TitleAndValue>
     </div>
   )
 }


### PR DESCRIPTION
### 概要
- EventPage コンポーネント内で、sports_type や prefecture を個別にAPIリクエストしていた処理を削除。
- 共通マスターデータ（sportsTypes, prefectures）を useInitialFormData フックから取得し、id から name をマッピングする実装に変更。
- イベント詳細取得時のAPIリクエスト回数が3回 → 1回に削減。
### 目的
- eventId ごとに sports_type と prefecture に対して個別にAPIリクエストし、将来的なユーザー増加に伴うパフォーマンス問題のリスクがある。
- 初期データとしてまとめて取得しておくことで、リクエスト数削減・レスポンス高速化・全体の効率化を実現。
### 変更内容
- fetchSportsType, fetchPrefecture 関数を削除。
- sportsTypes および prefectures を useInitialFormData から取得し、mapSelectedIdToName 関数で id から name を参照。
- useEffect 内の依存関係とガード条件を修正し、初期データ取得後のみ fetchEventDetails を実行するように変更。

close https://github.com/toshinori-m/stay_connect/issues/227