### PR TITLE
自己紹介画面のパスワード変更ボタン押下時に再設定メール送信画面へ遷移するよう修正

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -20,7 +20,8 @@
     "firebase": "^11.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.2.0"
+    "react-router-dom": "^7.2.0",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/frontend-react/src/pages/BasicSettingEditPage.tsx
+++ b/frontend-react/src/pages/BasicSettingEditPage.tsx
@@ -52,7 +52,6 @@ export default function BasicSettingEditPage() {
 
   const [fetchedId, setFetchedId] = useState<string | null>(null)
   const [errors, setErrors] = useState<string[]>([])
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const [formState, setFormState] = useState<FormState>({
     user: {
       name: "",
@@ -66,9 +65,8 @@ export default function BasicSettingEditPage() {
     error: null
   })
 
-  const [actionState, action] = useActionState(
+  const [actionState, action, isPending] = useActionState(
     async () => {
-      setIsSubmitting(true)
       
       try {
         // バリデーション
@@ -127,8 +125,6 @@ export default function BasicSettingEditPage() {
           // その他のエラーを設定
           return { errors: ["基本設定に誤りがあります。"] }
         }
-      } finally {
-        setIsSubmitting(false)
       }
     },
     { errors: [] }
@@ -378,7 +374,9 @@ export default function BasicSettingEditPage() {
           </ul>
           {ErrorList([...(formState.error ? [formState.error] : []), ...errors, ...actionState.errors])}
           <div className="text-center my-5">
-            <Button type="submit" variant="primary" size="sm" className="mr-4" disabled={isSubmitting}>更新</Button>
+            <Button type="submit" variant="primary" size="sm" className="mr-4" disabled={isPending}>
+              {isPending ? "更新中..." : "更新"}
+            </Button>
           </div>
         </form>
       </div>

--- a/frontend-react/src/pages/BasicSettingEditPage.tsx
+++ b/frontend-react/src/pages/BasicSettingEditPage.tsx
@@ -193,7 +193,7 @@ export default function BasicSettingEditPage() {
   }
   
   const redirectToSendEmail = () => {
-    console.log("パスワード再設定メール送信画面は次のissueで作成予定！") // TODO: 後続タスクで処理を追加
+    navigate("/send-email")
   }
 
   const isEmailNotificationEnabled = () => {

--- a/frontend-react/src/pages/BasicSettingEditPage.tsx
+++ b/frontend-react/src/pages/BasicSettingEditPage.tsx
@@ -51,6 +51,7 @@ export default function BasicSettingEditPage() {
 
   const [fetchedId, setFetchedId] = useState<string | null>(null)
   const [errors, setErrors] = useState<string[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [formState, setFormState] = useState<FormState>({
     user: {
       name: "",
@@ -66,6 +67,7 @@ export default function BasicSettingEditPage() {
 
   const [actionState, action] = useActionState(
     async () => {
+      setIsSubmitting(true)
       const newErrors: string[] = []
       const currentFormState = { ...formState }
 
@@ -115,6 +117,8 @@ export default function BasicSettingEditPage() {
           errors: ["基本設定に誤りがあります。"],
           formData: currentFormState
         }
+      } finally {
+        setIsSubmitting(false)
       }
     },
     { errors: [] }
@@ -364,7 +368,7 @@ export default function BasicSettingEditPage() {
           </ul>
           {ErrorList([...(formState.error ? [formState.error] : []), ...errors, ...actionState.errors])}
           <div className="text-center my-5">
-            <Button type="submit" variant="primary" size="sm" className="mr-4">更新</Button>
+            <Button type="submit" variant="primary" size="sm" className="mr-4" disabled={isSubmitting}>更新</Button>
           </div>
         </form>
       </div>

--- a/frontend-react/yarn.lock
+++ b/frontend-react/yarn.lock
@@ -2994,3 +2994,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.24.4:
+  version "3.24.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.4.tgz#e2e2cca5faaa012d76e527d0d36622e0a90c315f"
+  integrity sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==


### PR DESCRIPTION
### 概要
- 自己紹介を表示する画面（TBasicSettingEditPage）について、パスワード変更ボタン追加と登録ボタン改善を行いました。
### 変更内容（パスワード変更ボタン追加、登録ボタン改善）
- redirectToSendEmail 関数の中身を、console.log から navigate("/send-email") に修正しました。
- パスワード変更ボタンをクリックすると、/send-email に遷移してパスワード再設定メール送信画面を表示します。
- 今回の修正は、後続タスク予定だった遷移処理の実装を先行して対応したものです。
- isFormValid 関数を追加し、必要な項目が未入力の場合に <Button> を disabled にするよう制御。
- btn-disabled クラスを Tailwind カスタムスタイルに追加し、非活性状態でも統一された見た目・挙動となるよう調整。
- ユーザーが未入力の状態で送信しようとしても混乱しないよう、見た目と操作性を改善。
### 補足（登録ボタン改善）
- 他のページの登録ボタン改善については別issueにて行います。

close https://github.com/toshinori-m/stay_connect/issues/221