### PR TITLE
チャットルーム一覧にページネーション機能を追加

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -39,6 +39,8 @@ gem "rack-cors"
 gem 'devise', '~> 4.9', '>= 4.9.2'
 gem 'devise_token_auth', '~> 1.2', '>= 1.2.2'
 
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -103,6 +103,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -203,6 +215,7 @@ DEPENDENCIES
   devise_token_auth (~> 1.2, >= 1.2.2)
   dotenv-rails
   jbuilder (~> 2.10)
+  kaminari
   pg
   pry-byebug
   puma (~> 5.0)

--- a/backend/app/controllers/chat_rooms_controller.rb
+++ b/backend/app/controllers/chat_rooms_controller.rb
@@ -15,7 +15,13 @@ class ChatRoomsController < ApplicationController
   end
 
   def index
-    @chat_rooms_with_other_user = current_user.chat_rooms_with_other_users
+    page = (params[:page] || 1).to_i
+    per_page = 10
+    offset = (page - 1) * per_page
+
+    all_rooms = current_user.chat_rooms_with_other_users
+    @paginated_chat_rooms = all_rooms.slice(offset, per_page) || []
+    @total_pages = (all_rooms.size / per_page.to_f).ceil
   end
 
   def show

--- a/backend/app/controllers/chat_rooms_controller.rb
+++ b/backend/app/controllers/chat_rooms_controller.rb
@@ -14,14 +14,14 @@ class ChatRoomsController < ApplicationController
     render json: { errors: @chat_room.errors.full_messages }, status: 400 unless @chat_room.update(create_params)
   end
 
+  PER_PAGE = 10
   def index
-    page = (params[:page] || 1).to_i
-    per_page = 10
-    offset = (page - 1) * per_page
+    @paginated_chat_rooms = current_user
+      .chat_rooms_with_other_users
+      .page(params[:page])
+      .per(PER_PAGE)
 
-    all_rooms = current_user.chat_rooms_with_other_users
-    @paginated_chat_rooms = all_rooms.slice(offset, per_page) || []
-    @total_pages = (all_rooms.size / per_page.to_f).ceil
+    @total_pages = @paginated_chat_rooms.total_pages
   end
 
   def show

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -28,14 +28,11 @@ class User < ActiveRecord::Base
   end
 
   def chat_rooms_with_other_users
-    chat_rooms.eager_load(chat_room_users: :user).map do |room|
-      other_user = room.other_user(user_id: id)
-      {
-        chat_room: room,
-        other_user_name: other_user&.name,
-        other_user_id: other_user&.id
-      }
-    end
+    chat_rooms
+      .joins('INNER JOIN chat_room_users cru ON cru.chat_room_id = chat_rooms.id')
+      .joins('INNER JOIN users other_users ON other_users.id = cru.user_id')
+      .where.not('cru.user_id = ?', id)
+      .select('chat_rooms.*, cru.user_id AS other_user_id, other_users.name AS other_user_name')
   end
 
   private

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ActiveRecord::Base
       .joins('INNER JOIN chat_room_users cru ON cru.chat_room_id = chat_rooms.id')
       .joins('INNER JOIN users other_users ON other_users.id = cru.user_id')
       .where.not('cru.user_id = ?', id)
-      .select('chat_rooms.*, cru.user_id AS other_user_id, other_users.name AS other_user_name')
+      .select('DISTINCT chat_rooms.*, cru.user_id AS other_user_id, other_users.name AS other_user_name')
   end
 
   private

--- a/backend/app/views/chat_rooms/index.json.jbuilder
+++ b/backend/app/views/chat_rooms/index.json.jbuilder
@@ -1,9 +1,9 @@
 json.data @paginated_chat_rooms.map { |room|
   {
-    id: room[:chat_room].id,
-    paid_or_free: room[:chat_room].paid_or_free,
-    other_user_name: room[:other_user_name],
-    other_user_id: room[:other_user_id]
+    id: room.id,
+    paid_or_free: room.paid_or_free,
+    other_user_id: room.other_user_id,
+    other_user_name: room.other_user_name
   }
 }
 

--- a/backend/app/views/chat_rooms/index.json.jbuilder
+++ b/backend/app/views/chat_rooms/index.json.jbuilder
@@ -1,6 +1,10 @@
-json.array! @chat_rooms_with_other_user do |chat_room_with_other_user|
-  json.id chat_room_with_other_user[:chat_room].id
-  json.paid_or_free chat_room_with_other_user[:chat_room].paid_or_free
-  json.other_user_name chat_room_with_other_user[:other_user_name]
-  json.other_user_id chat_room_with_other_user[:other_user_id]
-end
+json.data @paginated_chat_rooms.map { |room|
+  {
+    id: room[:chat_room].id,
+    paid_or_free: room[:chat_room].paid_or_free,
+    other_user_name: room[:other_user_name],
+    other_user_id: room[:other_user_id]
+  }
+}
+
+json.totalPages @total_pages

--- a/frontend-react/src/pages/chatPage/ChatRoomListPage.tsx
+++ b/frontend-react/src/pages/chatPage/ChatRoomListPage.tsx
@@ -12,22 +12,31 @@ interface ChatRoom {
 export default function ChatRoomListPage() {
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([])
   const [errors, setErrors] = useState<string[]>([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
   const apiClient = useApiClient()
   const navigate = useNavigate()
 
   useEffect(() => {
-    fetchChatRoomList()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const fetchChatRoomList = async () => {
     setErrors([])
-    try {
-      const chatRoomsData = (await apiClient.get("/chat_rooms")).data
-      setChatRooms(chatRoomsData)
-    } catch {
-      setErrors(["チャットルームリストを表示できませんでした。"])
-    }
+
+    apiClient.get(`/chat_rooms?page=${currentPage}`)
+      .then((chatRoom) => {
+        setChatRooms(chatRoom.data.data)
+        setTotalPages(chatRoom.data.totalPages)
+      })
+      .catch (() => {
+        setErrors(["チャットルームリストを表示できませんでした。"])
+      })
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPage])
+
+  const handlePrevPage = () => {
+    if (currentPage > 1) setCurrentPage(currentPage - 1)
+  }
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages) setCurrentPage(currentPage + 1)
   }
 
   const editChatRoom = async (chatRoomId: number) => {
@@ -54,7 +63,7 @@ export default function ChatRoomListPage() {
       <div className="w-full md:w-3/5 xl:w-2/5 pb-7 shadow-gray-200 bg-sky-100 rounded-lg">
         <h2 className="text-center mb-7 pt-10 font-bold text-3xl text-blue-600">チャットルーム一覧</h2>
         <div className="flex flex-col items-center">
-          <ErrorDisplay className="text-center" tag="p" errors={(errors)}/>
+          <ErrorDisplay errors={(errors)}/>
 
           {chatRooms.map((chatRoom) => (
             <div 
@@ -68,6 +77,12 @@ export default function ChatRoomListPage() {
               </div>
             </div>
           ))}
+
+          <div className="flex justify-between items-center mt-6 w-72">
+            <Button variant="primary" size="sm" disabled={currentPage === 1} onClick={handlePrevPage}>前へ</Button>
+            <span className="mx-4 text-gray-700">{currentPage} / {totalPages}</span>
+            <Button variant="primary" size="sm" disabled={currentPage === totalPages} onClick={handleNextPage}>次へ</Button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 概要
#### 【フロントエンド】
- チャットルーム一覧画面（ChatRoomListPage.tsx）にページネーション機能を追加。
  - 現在ページ・全ページ数を状態管理。
  - API リクエストに page パラメータを付与。
  - 「前へ」「次へ」ボタンでページ切り替え可能。
  - エラーメッセージ表示用のコンポーネント ErrorList を実装。
#### 【バックエンド】
- ChatRoomsController#index アクションにページネーション処理を追加。
  - リクエストパラメータ page を受け取り、データを分割して返却。
  - totalPages を計算してレスポンスに含める。
- index.json.jbuilder をページネーション対応のレスポンス形式に変更。
  - エラーメッセージ表示用のコンポーネント ErrorList を実装。
#### 【期待される動作】
- チャットルーム一覧でデータを分割して取得し、表示のパフォーマンスが向上。
- 多数のチャットルームが存在しても画面表示が重くならない。

close https://github.com/toshinori-m/stay_connect/issues/210