### PR TITLE
PHP-FPM + Nginx によるbackendを構築

### DIFF
--- a/backend-php/Dockerfile
+++ b/backend-php/Dockerfile
@@ -8,9 +8,6 @@ RUN rm -rf /var/lib/apt/lists/* \
   && apt-get update --allow-insecure-repositories \
   && apt-get install -y tzdata php-fpm
 
-# TCP 9000で受けるように FastCGI 設定ファイルを上書き
-COPY etc/www.conf /etc/php/8.1/fpm/pool.d/www.conf
-
 WORKDIR /app
 
 CMD ["/usr/sbin/php-fpm8.1", "-F"]

--- a/backend-php/Dockerfile
+++ b/backend-php/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# GPG問題を避けるための応急処置を追加
+RUN rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
+  && apt-get update --allow-insecure-repositories \
+  && apt-get install -y tzdata php-fpm
+
+# TCP 9000で受けるように FastCGI 設定ファイルを上書き
+COPY etc/www.conf /etc/php/8.1/fpm/pool.d/www.conf
+
+WORKDIR /app
+
+CMD ["/usr/sbin/php-fpm8.1", "-F"]

--- a/backend-php/etc/www.conf
+++ b/backend-php/etc/www.conf
@@ -1,0 +1,11 @@
+[www]
+listen = 9000
+
+user = www-data
+group = www-data
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3

--- a/backend-php/public/index.php
+++ b/backend-php/public/index.php
@@ -1,0 +1,2 @@
+<?php
+echo "Hello World";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./backend-php:/app
+      - ./backend-php/etc/www.conf:/etc/php/8.1/fpm/pool.d/www.conf
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,25 +10,44 @@ services:
     ports:
       - 5432:5432
     
-  backend:
+  # backend:
+  #   build:
+  #     context: ./backend/
+  #     dockerfile: Dockerfile
+  #   command: bundle exec rails s -p 3000 -b '0.0.0.0'
+  #   volumes:
+  #     - ./backend:/myapp
+  #   environment:
+  #     TZ: Asia/Tokyo
+  #     RAILS_ENV: development
+  #     # DB_HOST: db
+  #     DB_USER: root
+  #     # MYSQL_ROOT_PASSWORD:
+  #   ports:
+  #     - "3001:3000"
+  #   depends_on:
+  #     - db
+  #   stdin_open: true
+  #   tty: true
+
+  backend-php:
     build:
-      context: ./backend/
+      context: ./backend-php
       dockerfile: Dockerfile
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
-      - ./backend:/myapp
-    environment:
-      TZ: Asia/Tokyo
-      RAILS_ENV: development
-      # DB_HOST: db
-      DB_USER: root
-      # MYSQL_ROOT_PASSWORD:
-    ports:
-      - "3001:3000"
+      - ./backend-php:/app
     depends_on:
       - db
-    stdin_open: true
-    tty: true
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "3002:80"
+    volumes:
+      - ./backend-php:/app
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - backend-php
 
   # frontend:
   #   build: 
@@ -54,7 +73,7 @@ services:
     ports:
       - "5173:5173"
     depends_on:
-      - backend
+      - backend-php
     stdin_open: true
     tty: true
     

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+
+    root /app/public;
+    index index.php index.html;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass backend-php:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME /app/public$fastcgi_script_name;
+        include fastcgi_params;
+    }
+}


### PR DESCRIPTION
### 概要
- Ubuntuベースで構成したPHP実行環境の構築
- php-fpm + Nginxにより `http://localhost:3002` で「Hello World」を表示

### 主な変更点
- backend-php サービスを新規追加
- PHP-FPM の設定を9000番ポートに変更
- Nginx のdefault.confを作成し、FastCGIでPHP処理を実行
- 動作確認用に public/index.php を作成（Hello World出力）

### 備考
- docker-compose.ymlのbackend（Rails）や frontend（Vue）はコメントアウト中

Closes https://github.com/toshinori-m/stay_connect/issues/243