### PR TITLE
ログイン機能の実装（/users/me認証＋uid登録対応、422ステータス仕様に統一）

### DIFF
--- a/backend-php/lib/authenticate.php
+++ b/backend-php/lib/authenticate.php
@@ -1,0 +1,12 @@
+<?php
+function authenticate_uid(): string {
+  $uid = $_SERVER['HTTP_UID'] ?? null;
+
+  if (!$uid) {
+    http_response_code(401);
+    echo json_encode(['error' => '認証情報が不足しています（uidが必要）']);
+    exit;
+  }
+
+  return $uid;
+}

--- a/backend-php/public/index.php
+++ b/backend-php/public/index.php
@@ -9,6 +9,9 @@ $routes = [
   'POST' => [
     '/users' => __DIR__ . '/../src/register.php',
   ],
+  'GET' => [
+    '/users/me' => __DIR__ . '/../src/users_me.php',
+  ]
 ];
 
 if (isset($routes[$requestMethod][$requestUri])) {

--- a/backend-php/src/register.php
+++ b/backend-php/src/register.php
@@ -64,13 +64,13 @@ try {
   if ($e->getCode() === '23505') {
     // メッセージ内に 'email' や 'uid' が含まれているか判定
     if (strpos($e->getMessage(), 'email') !== false) {
-      http_response_code(409);
+      http_response_code(422);
       echo json_encode(['error' => 'このメールアドレスはすでに登録されています。']);
     } elseif (strpos($e->getMessage(), 'uid') !== false) {
-      http_response_code(409);
+      http_response_code(422);
       echo json_encode(['error' => 'このUIDはすでに登録されています。']);
     } else {
-      http_response_code(409);
+      http_response_code(422);
       echo json_encode(['error' => '重複したデータが存在します。']);
     }
   } else {

--- a/backend-php/src/users_me.php
+++ b/backend-php/src/users_me.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/authenticate.php';
+
+header('Content-Type: application/json');
+
+$uid = authenticate_uid();
+
+try {
+    $pdo = getPDO();
+
+    $stmt = $pdo->prepare("SELECT id, name, email FROM users WHERE uid = :uid LIMIT 1");
+    $stmt->execute([':uid' => $uid]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$user) {
+        http_response_code(404);
+        echo json_encode(['error' => 'ユーザーが見つかりません']);
+        exit;
+    }
+
+    http_response_code(200);
+    echo json_encode($user);
+    exit(0);
+
+} catch (PDOException $e) {
+  // SELECT文でも予期せぬDB接続エラーなどがあり得るので明示
+  http_response_code(500);
+  echo json_encode([
+      'error' => 'データベースエラーが発生しました。',
+      'details' => $e->getMessage()
+  ]);
+} catch (Exception $e) {
+  http_response_code(500);
+  echo json_encode([
+      'error' => 'サーバーエラーが発生しました。',
+      'details' => $e->getMessage()
+  ]);
+}

--- a/frontend-react/src/pages/LoginPage.tsx
+++ b/frontend-react/src/pages/LoginPage.tsx
@@ -65,8 +65,12 @@ export default function LoginPage() {
       const user = userCredential.user
 
       try {
-        await apiClient.get("/users/me")
         setUser(user)
+        await apiClient.get("/users/me", {
+          headers: {
+            uid: user.uid,
+          }
+        })
         navigate("/home")
       } catch (error: unknown) {
         const axiosError = error as AxiosError
@@ -96,6 +100,11 @@ export default function LoginPage() {
       const result = await signInWithPopup(auth, provider)
       const firebaseUser = result.user
       setUser(firebaseUser)
+      await apiClient.get("/users/me", {
+        headers: {
+          uid: firebaseUser.uid,
+        }
+      })
       navigate("/home")
     } catch {
       setErrors(["googleアカウントでログインに失敗しました。再試行してください。"])


### PR DESCRIPTION
## 概要 
- メールアドレスおよびgoogleアカウントでログインよりhome画面へ遷移します。
- メールアドレスでログイン後、既存ユーザーであれば `/users/me` を通じてユーザー情報を取得し、存在しない場合は `/users` に対して登録リクエストを行う処理に対応するためのバックエンド実装を行いました。
- フロントエンドからのログイン確認用に `/users/me` エンドポイントを追加しました。
- Firebase Auth によるログイン後、uid をヘッダーに含めて送信することで認証判定を行います。
  - apiで`uid` ヘッダーを元にユーザーを特定するためです。
- 既存のメールアドレスやUIDに対する登録処理において、従来は `409 Conflict` を返していましたが、Rails実装では `422 Unprocessable Entity` を返していたため、フロントエンドのエラーハンドリング（navigate処理）と仕様を統一する目的で、`422` に変更しました。
- exit;についての記述は、exit(0);やexit(1);の修正を次のブランチで行います。

## 確認手順
### 1. urlへ`http://localhost:5173/`を入力し実行すると下の画面が表示ので赤枠の「ログイン」を実行

![新規メモ](https://github.com/user-attachments/assets/0a2a095d-daf3-4e41-aba6-40ec28aa4689)

### 2. 下の画面が表示するので、このアプリのユーザー登録を行った方法でログイン（ユーザー登録：緑枠内の「アカウントをお持ちでない方はこちら」から項目3の画面でユーザー登録を行った方法）

  a. 項目3画面で「メールアドレスで登録」を実行　⇨　赤枠内の「メールアドレス」および「パスワード」を入力しログインボタンを実行　→ 項目6へ
     i. 「メールアドレス」を忘れた場合は、項目4、もしくは項目5で確認 
     ii.  「パスワード」を忘れた場合は、パスワードを忘れた場合の実装を現在は行えていないので再度新規ユーザー登録から実行

  b. 項目3画面で「googleアカウントで登録」を行った　⇨　青枠内の「googleアカウントでログイン」　→ 項目7へ

![新規メモ](https://github.com/user-attachments/assets/80318642-f546-40ca-a418-8da2617cc721)

### 3. 項目2で「アカウントをお持ちでない方はこちら」を押した場合の画面

![新規メモ](https://github.com/user-attachments/assets/52377213-06fd-418c-8f0a-ce515f534f17)

### 4. firebaseを使用している場合、firebaseの下の画面からemailを確認

![新規メモ](https://github.com/user-attachments/assets/59f397b3-ccca-4e4f-88c4-86c414906121)

### 5. firebaseを使用していない場合、ターミナルにて下を実行しemailを確認

   (1) $ docker ps
```
CONTAINER ID   IMAGE                         COMMAND                   CREATED        STATUS         PORTS                    NAMES
818cbdfc87be   stay_connect-frontend-react   "docker-entrypoint.s…"   18 hours ago   Up 18 hours    0.0.0.0:5173->5173/tcp   stay_connect-frontend-react-1
a35ce64edb06   stay_connect-frontend         "docker-entrypoint.s…"   18 hours ago   Up 18 hours    0.0.0.0:81->8080/tcp     stay_connect-frontend-1
3606f1c2ad36   nginx:alpine                  "/docker-entrypoint.…"   18 hours ago   Up 18 hours    0.0.0.0:3002->80/tcp     stay_connect-nginx-1
2a45bfa173cd   stay_connect-backend          "entrypoint.sh bundl…"   18 hours ago   Up 18 hours    0.0.0.0:3001->3000/tcp   stay_connect-backend-1
e2aab62aa9a9   stay_connect-backend-php      "/usr/sbin/php-fpm8.…"   18 hours ago   Up 18 hours                             stay_connect-backend-php-1
f8ba79330191   postgres                      "docker-entrypoint.s…"   18 hours ago   Up 6 minutes   0.0.0.0:5432->5432/tcp   stay_connect-db-1
```
   (2) $ docker compose exec db bash
   (3) # psql -U postgres
```
psql (17.5 (Debian 17.5-1.pgdg120+1))
Type "help" for help.
```
   (4) postgres=# \l
```
                                                        List of databases
       Name        |  Owner   | Encoding | Locale Provider |  Collate   |   Ctype    | Locale | ICU Rules |   Access privileges   
-------------------+----------+----------+-----------------+------------+------------+--------+-----------+-----------------------
 myapp_development | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |        |           | 
 myapp_test        | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |        |           | 
 postgres          | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |        |           | 
 template0         | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |        |           | =c/postgres          +
                   |          |          |                 |            |            |        |           | postgres=CTc/postgres
 template1         | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |        |           | =c/postgres          +
                   |          |          |                 |            |            |        |           | postgres=CTc/postgres
(5 rows)
```
   (5) postgres=# \c myapp_development
```
You are now connected to database "myapp_development" as user "postgres".
```
   (6) myapp_development=# SELECT * FROM users;
```
 id | provider |             uid              |    name     |                email                 | email_notification | encrypted_password | image | birthday | sex | self_introduction | tokens |         created_at         |         updated_at         | reset_password_token | reset_password_sent_at | allow_password_change 
----+----------+------------------------------+-------------+--------------------------------------+--------------------+--------------------+-------+----------+-----+-------------------+--------+----------------------------+----------------------------+----------------------+------------------------+-----------------------
  4 |          | pT44mVam1nWfMZdgbI0cr4LEM1I3 | matsumatsu3 | matsumatsu3@nuxt.rails.todoapp       | t                  |                    |       |          |     |                   |        | 2025-06-03 08:01:36.743506 | 2025-06-03 08:01:36.743506 |                      |                        | 
```
この表のemai（例）`matsumatsu3@nuxt.rails.todoapp`を使用
### 6. ログインを成功すると下のhome画面へ遷移
画面右側のネットワーク→ヘッダーのmeのプレビューに「email」「id」「name」が表示していればok

![新規メモ](https://github.com/user-attachments/assets/ed0fc283-1687-4d4b-81ae-014dd86d57db)

そして画面右側のネットワーク→ヘッダーのmeのヘッダーからステータス コード200が表示

![新規メモ](https://github.com/user-attachments/assets/7f11f209-21d4-4554-8b95-90dccb007c4f)



close https://github.com/toshinori-m/stay_connect/issues/250