### PR TITLE
/searches および初期データ用エンドポイントのPHP実装

### DIFF
--- a/backend-php/lib/authenticate.php
+++ b/backend-php/lib/authenticate.php
@@ -1,11 +1,12 @@
 <?php
-function authenticate_uid(): string {
+function authenticate_uid(): string
+{
   $uid = $_SERVER['HTTP_UID'] ?? null;
 
   if (!$uid) {
     http_response_code(401);
     echo json_encode(['error' => '認証情報が不足しています（uidが必要）']);
-    exit;
+    exit(1);
   }
 
   return $uid;

--- a/backend-php/lib/error_handler.php
+++ b/backend-php/lib/error_handler.php
@@ -1,0 +1,20 @@
+<?php
+function handlePDOException(PDOException $e): void
+{
+  http_response_code(500);
+  echo json_encode([
+    'error' => 'データベースエラーが発生しました。',
+    'details' => $e->getMessage()
+  ]);
+  exit(1);
+}
+
+function handleException(Exception $e): void
+{
+  http_response_code(500);
+  echo json_encode([
+    'error' => 'サーバーエラーが発生しました。',
+    'details' => $e->getMessage()
+  ]);
+  exit(1);
+}

--- a/backend-php/public/index.php
+++ b/backend-php/public/index.php
@@ -11,6 +11,11 @@ $routes = [
   ],
   'GET' => [
     '/users/me' => __DIR__ . '/../src/users_me.php',
+    '/sports_types' => __DIR__ . '/../src/sports_types.php',
+    '/sports_disciplines' => __DIR__ . '/../src/sports_disciplines.php',
+    '/prefectures' => __DIR__ . '/../src/prefectures.php',
+    '/target_ages' => __DIR__ . '/../src/target_ages.php',
+    '/searches' => __DIR__ . '/../src/searches.php'
   ]
 ];
 
@@ -19,4 +24,5 @@ if (isset($routes[$requestMethod][$requestUri])) {
 } else {
   http_response_code(404);
   echo json_encode(['error' => 'Not Found']);
+  exit(1);
 }

--- a/backend-php/src/prefectures.php
+++ b/backend-php/src/prefectures.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+
+header('Content-Type: application/json');
+
+try {
+  $pdo = getPDO();
+
+  $stmt = $pdo->query("SELECT id, name FROM prefectures");
+  $prefectures = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+  http_response_code(200);
+  echo json_encode([
+    'message' => '成功しました',
+    'data' => $prefectures
+  ]);
+  exit(0);
+
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/searches.php
+++ b/backend-php/src/searches.php
@@ -1,0 +1,105 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/authenticate.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+
+header('Content-Type: application/json');
+
+function sexLabel($sexInt) {
+  switch ($sexInt) {
+    case 0: return 'man';
+    case 1: return 'woman';
+    case 2: return 'mix';
+    case 3: return 'man_and_woman';
+    default: return 'unknown';
+  }
+}
+
+try {
+  $pdo = getPDO();
+
+  // ベースの recruitments 一覧を取得
+  $sql = "
+    SELECT 
+      r.id, r.name, r.purpose_body, r.sex,
+      st.name AS sports_type_name,
+      p.name AS prefecture_name
+    FROM recruitments r
+    LEFT JOIN sports_types st ON r.sports_type_id = st.id
+    LEFT JOIN prefectures p ON r.prefecture_id = p.id
+    WHERE 1 = 1
+  ";
+
+  $params = [];
+  if (!empty($_GET['sports_type_name'])) {
+    $sql .= " AND st.name = :sports_type_name";
+    $params[':sports_type_name'] = $_GET['sports_type_name'];
+  }
+  if (!empty($_GET['sports_discipline_name'])) {
+    $sql .= "
+      AND EXISTS (
+        SELECT 1
+        FROM recruitment_sports_disciplines rsd
+        JOIN sports_disciplines sd ON sd.id = rsd.sports_discipline_id
+        WHERE rsd.recruitment_id = r.id
+          AND sd.name = :sports_discipline_name
+      )
+    ";
+    $params[':sports_discipline_name'] = $_GET['sports_discipline_name'];
+  }
+  if (!empty($_GET['prefecture_name'])) {
+    $sql .= " AND p.name = :prefecture_name";
+    $params[':prefecture_name'] = $_GET['prefecture_name'];
+  }
+  if (!empty($_GET['target_age_name'])) {
+    $sql .= "
+      AND EXISTS (
+        SELECT 1
+        FROM recruitment_target_ages rta
+        JOIN target_ages ta ON ta.id = rta.target_age_id
+        WHERE rta.recruitment_id = r.id
+          AND ta.name = :target_age_name
+      )
+    ";
+    $params[':target_age_name'] = $_GET['target_age_name'];
+  }
+
+  $stmt = $pdo->prepare($sql);
+  $stmt->execute($params);
+  $recruitments = $stmt->fetchAll(PDO::FETCH_ASSOC);
+  if (!$recruitments) $recruitments = [];
+
+  foreach ($recruitments as &$recruitment) {
+    $rid = $recruitment['id'];
+    $recruitment['sex'] = sexLabel($recruitment['sex']);
+
+    // 種目
+    $stmtDisciplines = $pdo->prepare("
+      SELECT sd.id, sd.name
+      FROM recruitment_sports_disciplines rsd
+      JOIN sports_disciplines sd ON sd.id = rsd.sports_discipline_id
+      WHERE rsd.recruitment_id = :rid
+    ");
+    $stmtDisciplines->execute([':rid' => $rid]);
+    $recruitment['sports_discipline_name'] = $stmtDisciplines->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+    // 対象年齢
+    $stmtAges = $pdo->prepare("
+      SELECT ta.id, ta.name
+      FROM recruitment_target_ages rta
+      JOIN target_ages ta ON ta.id = rta.target_age_id
+      WHERE rta.recruitment_id = :rid
+    ");
+    $stmtAges->execute([':rid' => $rid]);
+    $recruitment['target_age_name'] = $stmtAges->fetchAll(PDO::FETCH_ASSOC) ?: [];
+  }
+
+  echo json_encode($recruitments);
+  http_response_code(200);
+  exit(0);
+
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/sports_disciplines.php
+++ b/backend-php/src/sports_disciplines.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+
+header('Content-Type: application/json');
+
+try {
+  $pdo = getPDO();
+
+  // パラメータの取得とバリデーション
+  $sportsTypeId = isset($_GET['sports_type_id']) ? $_GET['sports_type_id'] : null;
+
+  if (!$sportsTypeId || !is_numeric($sportsTypeId)) {
+    http_response_code(400);
+    echo json_encode(['message' => 'sports_type_idを指定してください']);
+    exit(1);
+  }
+
+  // 絞り込みクエリ実行
+  $stmt = $pdo->prepare("SELECT id, name, sports_type_id FROM sports_disciplines WHERE sports_type_id = :sports_type_id");
+  $stmt->execute([':sports_type_id' => $sportsTypeId]);
+  $sportsDisciplines = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+  http_response_code(200);
+  echo json_encode([
+    'message' => '成功しました',
+    'data' => $sportsDisciplines ?: []
+  ]);
+  exit(0);
+
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/sports_types.php
+++ b/backend-php/src/sports_types.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+
+header('Content-Type: application/json');
+
+try {
+  $pdo = getPDO();
+
+  $stmt = $pdo->query("SELECT id, name FROM sports_types");
+  $sportsTypes = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+  http_response_code(200);
+  echo json_encode([
+    'message' => '成功しました',
+    'data' => $sportsTypes
+  ]);
+  exit(0);
+
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/target_ages.php
+++ b/backend-php/src/target_ages.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+
+header('Content-Type: application/json');
+
+try {
+  $pdo = getPDO();
+
+  $stmt = $pdo->query("SELECT id, name FROM target_ages");
+  $targetAges = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+  http_response_code(200);
+  echo json_encode([
+    'message' => '成功しました',
+    'data' => $targetAges,
+  ]);
+  exit(0);
+
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/users_me.php
+++ b/backend-php/src/users_me.php
@@ -1,39 +1,30 @@
 <?php
 require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/../lib/authenticate.php';
+require_once __DIR__ . '/../lib/error_handler.php';
 
 header('Content-Type: application/json');
 
 $uid = authenticate_uid();
 
 try {
-    $pdo = getPDO();
+  $pdo = getPDO();
 
-    $stmt = $pdo->prepare("SELECT id, name, email FROM users WHERE uid = :uid LIMIT 1");
-    $stmt->execute([':uid' => $uid]);
-    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+  $stmt = $pdo->prepare("SELECT id, name, email FROM users WHERE uid = :uid LIMIT 1");
+  $stmt->execute([':uid' => $uid]);
+  $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
-    if (!$user) {
-        http_response_code(404);
-        echo json_encode(['error' => 'ユーザーが見つかりません']);
-        exit;
-    }
+  if (!$user) {
+    http_response_code(404);
+    echo json_encode(['error' => 'ユーザーが見つかりません']);
+    exit(1);
+  }
 
-    http_response_code(200);
-    echo json_encode($user);
-    exit(0);
-
+  http_response_code(200);
+  echo json_encode($user);
+  exit(0);
 } catch (PDOException $e) {
-  // SELECT文でも予期せぬDB接続エラーなどがあり得るので明示
-  http_response_code(500);
-  echo json_encode([
-      'error' => 'データベースエラーが発生しました。',
-      'details' => $e->getMessage()
-  ]);
+  handlePDOException($e);
 } catch (Exception $e) {
-  http_response_code(500);
-  echo json_encode([
-      'error' => 'サーバーエラーが発生しました。',
-      'details' => $e->getMessage()
-  ]);
+  handleException($e);
 }


### PR DESCRIPTION
## 概要
### 追加したファイルとエンドポイント: GET /searches
- ファイル: `backend-php/src/searches.php`
- パラメータによる絞り込み検索（sports_type_name, sports_discipline_name, prefecture_name, target_age_name）に対応
- `string_agg` を使用し、関連テーブルの名称をカンマ区切りで集約
- 認証付き（`authenticate_uid()` 使用）

### その他初期データ取得API
- `/sports_types` → `sports_types.php`
- `/sports_disciplines` → `sports_disciplines.php`
- `/prefectures` → `prefectures.php`
- `/target_ages` → `target_ages.php`
- 各APIは、`id` と `name` を返す
- レスポンス形式を `{ message: "...", data: [...] }` に統一

## その他の変更
- `public/index.php` に上記5つの GET ルートを追加
- エラー処理を共通の `lib/error_handler.php` に委譲して統一
- `exit;`と書いていた箇所を`exit(0);`もしくは`exit(1);`へ修正
- `searches.php` の SQL 文は現時点では仮の状態です（イベント作成API未実装のため）。今後の `POST /recruitments` 実装にあわせて、本検索機能のSQLの精査・修正を行う予定です。

## 変更の確認手順
[ログイン機能の実装（/users/me認証＋uid登録対応、422ステータス仕様に統一）](https://github.com/toshinori-m/stay_connect/pull/252)　終了時は新規ユーザー登録時、もしくはログイン時はのhome画面は下のように表示していました。

![新規メモ](https://github.com/user-attachments/assets/3a3907e3-7bac-4f2e-9609-8f143e8424d4)

今回のPRにより新規ユーザー登録時、もしくはログイン時はのhome画面は下のようになります。
- カテゴリ検索下のエラーがなくなる。
- ネットワークのsports_types、prefectures、target_ages、searches、sports_types、prefectures、target_ages、searchesのステータスが200となり、コンソールの404エラーがなくなります。

![新規メモ](https://github.com/user-attachments/assets/a553de5b-210e-444c-af20-fa1cac083e82)



close https://github.com/toshinori-m/stay_connect/issues/253