### PR TITLE
本番環境に合わせたCORS設定とAPIリクエストに認証情報（credentials）を追加

### DIFF
--- a/backend/app/controllers/sessions_controller.rb
+++ b/backend/app/controllers/sessions_controller.rb
@@ -1,12 +1,12 @@
 class SessionsController < ApplicationController
   def create
-    uid = params[:uid]
+    uid = params[:uid] || params.dig(:session, :uid)
     user = User.find_by(uid: uid)
 
     if user
       response.set_header('access-token', SecureRandom.hex(16))
       response.set_header('client', SecureRandom.hex(8))
-      response.set_header('uid', uid)
+      response.set_header('uid', user.uid)
 
       render json: { message: 'ログイン成功' }, status: :ok
     else

--- a/backend/app/controllers/sessions_controller.rb
+++ b/backend/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+class SessionsController < ApplicationController
+  def create
+    uid = params[:uid]
+    user = User.find_by(uid: uid)
+
+    if user
+      response.set_header('access-token', SecureRandom.hex(16))
+      response.set_header('client', SecureRandom.hex(8))
+      response.set_header('uid', uid)
+
+      render json: { message: 'ログイン成功' }, status: :ok
+    else
+      render json: { error: 'ユーザーが存在しません' }, status: :unauthorized
+    end
+  end
+end

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -4,6 +4,11 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     @user.save!
+    response.set_header('access-token', SecureRandom.hex(16))
+    response.set_header('client', SecureRandom.hex(8))
+    response.set_header('uid', @user.uid)
+
+    render :create, status: :created
   rescue ActiveRecord::RecordInvalid => e
     render json: { errors: e.record.errors.messages }, status: :unprocessable_entity 
   end

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -17,6 +17,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "*",
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head],
-      credentials: false
+      credentials: true
   end
 end

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -16,6 +16,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
+      expose: ['access-token', 'client', 'uid'],
       methods: [:get, :post, :put, :patch, :delete, :options, :head],
       credentials: true
   end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
         resources :chat_room_users, only: [:index, :create]
       end
     end
+    post '/sessions', to: 'sessions#create'
     root to: proc { [204, {}, ['']] }
   end
 end

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -1,14 +1,16 @@
 import axios from 'axios'
 
 export default function getApiClient() {
-  const user = localStorage.getItem('currentUser')
-  const uid = user ? JSON.parse(user).uid : null
+  const user = JSON.parse(localStorage.getItem('currentUser') || '{}')
   const apiBaseUrl = process.env.VUE_APP_API_BASE_URL || 'http://localhost:3001'
 
   return axios.create({
     baseURL: apiBaseUrl,
+    withCredentials: true,
     headers: {
-      'uid': uid
+      'access-token': user['access-token'],
+      'client': user['client'],
+      'uid': user['uid']
     }
   })
 }

--- a/frontend/src/views/BasicSetting/BasicSettingEditPage.vue
+++ b/frontend/src/views/BasicSetting/BasicSettingEditPage.vue
@@ -96,7 +96,9 @@ export default {
         const apiClient = getApiClient()
         this.error = null
         const uid = JSON.parse(localStorage.getItem('currentUser')).uid
-        const res = await apiClient.get(`/users/${uid}`)
+        const res = await apiClient.get(`/users/${uid}`, {
+          withCredentials: true
+        })
         this.user = res.data.data
       } catch {
         this.$router.push({name: 'LoginPage'})
@@ -119,7 +121,9 @@ export default {
           formData.append('user[image]', this.imageFile);
         }
         if (!this.user || !this.user.id) return
-        await apiClient.patch(`/users/${this.user.id}`, formData)
+        await apiClient.patch(`/users/${this.user.id}`, formData, {
+          withCredentials: true
+        })
         this.$router.push({ name: 'HomePage' })
       } catch {
         this.error = '基本設定に誤りがあります。'

--- a/frontend/src/views/BasicSetting/UserProfilePage.vue
+++ b/frontend/src/views/BasicSetting/UserProfilePage.vue
@@ -51,7 +51,9 @@ export default {
       try {
         this.errors = []
         const apiClient = getApiClient()
-        const res = await apiClient.get(`/users_profile/${this.$route.params.userId}`)
+        const res = await apiClient.get(`/users_profile/${this.$route.params.userId}`, {
+          withCredentials: true
+        })
         this.userProfile = res.data.data
         this.fetchTeams()
       } catch {
@@ -64,6 +66,8 @@ export default {
         const apiClient = getApiClient()
         const res = await apiClient.post('/chat_rooms', {
           other_user_id: this.userProfile.id
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'ChatRoomPage', params: { id: res.data.data.id } })
       } catch {
@@ -74,7 +78,9 @@ export default {
       try {
         this.errors = []
         const apiClient = getApiClient()
-        const res = await apiClient.get(`/users/${this.userProfile.id}/teams_profile`)
+        const res = await apiClient.get(`/users/${this.userProfile.id}/teams_profile`, {
+          withCredentials: true
+        })
         this.teams = res.data
       } catch {
         this.errors.push('チーム情報を取得できませんでした。')
@@ -92,7 +98,9 @@ export default {
       try {
         this.errors = []
         const apiClient = getApiClient();
-        const res = await apiClient.get('/users/show')
+        const res = await apiClient.get('/users/show', {
+          withCredentials: true
+        })
         this.currentUser = res.data.data
       } catch {
         console.error('現在のユーザーを取得できませんでした')

--- a/frontend/src/views/ChatRoom/ChatRoomListPage.vue
+++ b/frontend/src/views/ChatRoom/ChatRoomListPage.vue
@@ -34,7 +34,9 @@ export default {
       try {
         const apiClient = getApiClient()
         this.error = null
-        const res = await apiClient.get('/chat_rooms')
+        const res = await apiClient.get('/chat_rooms', {
+          withCredentials: true
+        })
         this.chat_rooms = res.data
       } catch (error) {
         this.error = error.response ? error.response.data :'チャットルームを表示できませんでした。'
@@ -44,7 +46,9 @@ export default {
       try {
         this.error = null
         const apiClient = getApiClient()
-        const res = await apiClient.delete(`/chat_rooms/${chatRoomId}`)
+        const res = await apiClient.delete(`/chat_rooms/${chatRoomId}`, {
+          withCredentials: true
+        })
         this.chat_rooms = res.data
         this.$router.push({ name: 'ChatRoomListPage' })
       } catch {

--- a/frontend/src/views/ChatRoom/ChatRoomPage.vue
+++ b/frontend/src/views/ChatRoom/ChatRoomPage.vue
@@ -56,7 +56,9 @@ export default {
       try {
         this.errors = []
         const apiClient = getApiClient()
-        const res = await apiClient.get(`/chat_rooms/${this.$route.params.id}`)
+        const res = await apiClient.get(`/chat_rooms/${this.$route.params.id}`, {
+          withCredentials: true
+        })
         this.chatRoom = res.data.chat_room
         this.otherUserName = res.data.other_user.name
       } catch {
@@ -67,7 +69,9 @@ export default {
       try {
         this.errors = []
         const apiClient = getApiClient()
-        const res = await apiClient.get(`/chat_rooms/${this.$route.params.id}/chat_messages`)
+        const res = await apiClient.get(`/chat_rooms/${this.$route.params.id}/chat_messages`, {
+          withCredentials: true
+        })
         this.messages = res.data
       } catch {
         this.errors.push('チャットルームを表示できませんでした。')
@@ -81,6 +85,8 @@ export default {
           chat_message: { 
             message: this.message
           }
+        }, {
+          withCredentials: true
         })
         this.message = ''
       } catch (errors) {

--- a/frontend/src/views/EventMaking/EventPage.vue
+++ b/frontend/src/views/EventMaking/EventPage.vue
@@ -52,7 +52,9 @@ export default {
         this.errors = []
         const recruitmentId = this.$route.params.id
         const apiClient = getApiClient()
-        const res = await apiClient.get(`/recruitments/${recruitmentId}`)
+        const res = await apiClient.get(`/recruitments/${recruitmentId}`, {
+          withCredentials: true
+        })
         this.eventDetails = res.data.data
         this.getPrefectures()
         await this.getSportsType()

--- a/frontend/src/views/EventMaking/EventSettingEditPage.vue
+++ b/frontend/src/views/EventMaking/EventSettingEditPage.vue
@@ -203,7 +203,9 @@ export default {
         const apiClient = getApiClient()
         this.errors = []
         const recruitmentId = this.$route.params.id;
-        const res = await apiClient.get(`/recruitments/${recruitmentId}`)
+        const res = await apiClient.get(`/recruitments/${recruitmentId}`, {
+          withCredentials: true
+        })
         this.recruitments = res.data.data
         const rdsRes = await apiClient.get(`/recruitments/${recruitmentId}/sports_disciplines`)
         this.recruitment_sports_disciplines = rdsRes.data
@@ -293,6 +295,8 @@ export default {
             prefecture_id: this.prefecture_selected,
             target_age_ids: targetAgeIds
           }
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'EventSettingListPage' })
       } catch (error) {
@@ -304,7 +308,9 @@ export default {
         const apiClient = getApiClient()
         this.errors = []
         if (this.recruitments.id !== recruitmentId) return
-        await apiClient.delete(`/recruitments/${recruitmentId}`)
+        await apiClient.delete(`/recruitments/${recruitmentId}`, {
+          withCredentials: true
+        })
         this.$router.push({ name: 'EventSettingListPage' })
       } catch {
         this.errors.push('イベントを削除出来ませんでした。')

--- a/frontend/src/views/EventMaking/EventSettingListPage.vue
+++ b/frontend/src/views/EventMaking/EventSettingListPage.vue
@@ -45,7 +45,9 @@ export default {
       try {
         this.error = null
         const apiClient = getApiClient()
-        const res = await apiClient.delete(`/recruitments/${recruitmentId}`)
+        const res = await apiClient.delete(`/recruitments/${recruitmentId}`,{
+          withCredentials: true
+        })
         this.recruitments = res.data
         this.$router.push({ name: 'EventSettingListPage' })
       } catch {

--- a/frontend/src/views/EventMaking/EventSettingPage.vue
+++ b/frontend/src/views/EventMaking/EventSettingPage.vue
@@ -232,6 +232,8 @@ export default {
             prefecture_id: this.prefecture_selected,
             target_age_ids: targetAgeIds
           }
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'HomePage' })
       } catch (error) {

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -140,7 +140,10 @@ export default {
           prefecture_name: this.prefecture_selected.name,
           target_age_name: this.target_age_selected.name,
         }
-        const res = await apiClient.get('/searches', { params })
+        const res = await apiClient.get('/searches', {
+          params,
+          withCredentials: true
+        })
         this.recruitments = res.data
       } catch (error) {
         let message

--- a/frontend/src/views/LoginPage.vue
+++ b/frontend/src/views/LoginPage.vue
@@ -27,6 +27,7 @@
 </template>
 
 <script>
+import getApiClient from '@/lib/apiClient'
 import { auth } from "@/plugins/firebase"
 import { signInWithEmailAndPassword } from 'firebase/auth'
 import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth'
@@ -45,9 +46,15 @@ export default {
         this.error = null
         const userCredential = await signInWithEmailAndPassword(auth, this.email, this.password)
         const user = userCredential.user
+        const apiClient = getApiClient()
+        const res = await apiClient.post('/sessions', {
+          uid: user.uid
+        })
         this.$store.commit('setUser', {
           email: user.email,
-          uid: user.uid
+          uid: res.headers['uid'],
+          'access-token': res.headers['access-token'],
+          client: res.headers['client']
         })
         this.$router.push({ name: 'HomePage' })
       } catch {
@@ -60,10 +67,16 @@ export default {
         const provider = new GoogleAuthProvider()
         const result = await signInWithPopup(auth, provider)
         const user = result.user
+        const apiClient = getApiClient()
+        const res = await apiClient.post('/sessions', {
+          uid: user.uid
+        })
         this.$store.commit('setUser', {
           name: user.displayName,
           email: user.email,
-          uid: user.uid
+          uid: res.headers['uid'],
+          'access-token': res.headers['access-token'],
+          client: res.headers['client']
         })
         this.$router.push({ name: 'HomePage' })
       } catch {

--- a/frontend/src/views/LoginPage.vue
+++ b/frontend/src/views/LoginPage.vue
@@ -56,6 +56,13 @@ export default {
           'access-token': res.headers['access-token'],
           client: res.headers['client']
         })
+        localStorage.setItem('currentUser', JSON.stringify({
+          name: user.displayName,
+          email: user.email,
+          uid: res.headers['uid'],
+          'access-token': res.headers['access-token'],
+          client: res.headers['client']
+        }))
         this.$router.push({ name: 'HomePage' })
       } catch {
         this.error = 'メールアドレスかパスワードが違います'
@@ -78,6 +85,13 @@ export default {
           'access-token': res.headers['access-token'],
           client: res.headers['client']
         })
+        localStorage.setItem('currentUser', JSON.stringify({
+          name: user.displayName,
+          email: user.email,
+          uid: res.headers['uid'],
+          'access-token': res.headers['access-token'],
+          client: res.headers['client']
+        }))
         this.$router.push({ name: 'HomePage' })
       } catch {
         this.error = "ユーザー登録からGoogleアカウントで登録して下さい"

--- a/frontend/src/views/MakingIntroductions/PrefectureEditPage.vue
+++ b/frontend/src/views/MakingIntroductions/PrefectureEditPage.vue
@@ -39,7 +39,7 @@ export default {
         const res = await apiClient.get(`/prefectures/`)
         this.prefectures = res.data.data
       } catch {
-      this.error = '競技名を表示できませんでした。'
+      this.error = '都道府県を表示できませんでした。'
       }
     },
     async editPrefecture(prefectureId) {
@@ -50,20 +50,24 @@ export default {
         if (!prefecture) return;
         await apiClient.patch(`/prefectures/${prefectureId}`, {
           name: prefecture.name,
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'PrefecturePage' })
       } catch {
-        this.error = '競技名に誤りがあります。'
+        this.error = '都道府県に誤りがあります。'
       }
     },
     async deletePrefecture(prefectureId) {
       try {
         const apiClient = getApiClient()
         this.error = null
-        await apiClient.delete(`/prefectures/${prefectureId}`)
+        await apiClient.delete(`/prefectures/${prefectureId}`, {
+          withCredentials: true
+        })
         this.$router.push({ name: 'PrefecturePage' })
       } catch {
-        this.error = '競技名を削除出来ませんでした。'
+        this.error = '都道府県を削除出来ませんでした。'
       }
     },
     prefectureCancel() {

--- a/frontend/src/views/MakingIntroductions/PrefecturePage.vue
+++ b/frontend/src/views/MakingIntroductions/PrefecturePage.vue
@@ -33,6 +33,8 @@ export default {
         this.error = null
         await apiClient.post('/prefectures', {
           name: this.name
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'EventSettingPage' })
       } catch {

--- a/frontend/src/views/MakingIntroductions/SportsDisciplineEditPage.vue
+++ b/frontend/src/views/MakingIntroductions/SportsDisciplineEditPage.vue
@@ -60,7 +60,8 @@ export default {
         const res = await apiClient.get('/sports_disciplines', {
           params: {
             sports_type_id: this.sport_type_selected.id
-          }
+          },
+          withCredentials: true
         })
         this.sports_disciplines = res.data.data
       } catch {
@@ -75,6 +76,8 @@ export default {
         if (!sportsDiscipline) return;
         await apiClient.patch(`/sports_disciplines/${sportsDisciplineId}`, {
           name: sportsDiscipline.name
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'SportsDisciplinePage' })
       } catch {
@@ -85,7 +88,9 @@ export default {
       try {
         const apiClient = getApiClient()
         this.error = null
-        await apiClient.delete(`/sports_disciplines/${sportsDisciplineId}`)
+        await apiClient.delete(`/sports_disciplines/${sportsDisciplineId}`, {
+          withCredentials: true
+        })
         this.$router.push({ name: 'SportsDisciplinePage' })
       } catch {
         this.error = '競技名を削除出来ませんでした。'

--- a/frontend/src/views/MakingIntroductions/SportsDisciplinePage.vue
+++ b/frontend/src/views/MakingIntroductions/SportsDisciplinePage.vue
@@ -56,6 +56,8 @@ export default {
         await apiClient.post('/sports_disciplines', {
           sports_type_id: this.selected,
           name: this.name
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'EventSettingPage' })
       } catch {

--- a/frontend/src/views/MakingIntroductions/SportsTypeEditPage.vue
+++ b/frontend/src/views/MakingIntroductions/SportsTypeEditPage.vue
@@ -50,6 +50,8 @@ export default {
         if (!sportsType) return;
         await apiClient.patch(`/sports_types/${sportsTypeId}`, {
           name: sportsType.name
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'SportsTypePage' })
       } catch {
@@ -60,7 +62,9 @@ export default {
       try {
         const apiClient = getApiClient()
         this.error = null
-        await apiClient.delete(`/sports_types/${sportsTypeId}`)
+        await apiClient.delete(`/sports_types/${sportsTypeId}`, {
+          withCredentials: true
+        })
         this.$router.push({ name: 'SportsTypePage' })
       } catch {
         this.error = '競技名を削除出来ませんでした。'

--- a/frontend/src/views/MakingIntroductions/SportsTypePage.vue
+++ b/frontend/src/views/MakingIntroductions/SportsTypePage.vue
@@ -33,6 +33,8 @@ export default {
         this.error = null
         await apiClient.post('/sports_types', {
           name: this.name
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'EventSettingPage' })
       } catch {

--- a/frontend/src/views/MakingIntroductions/TargetAgeEditPage.vue
+++ b/frontend/src/views/MakingIntroductions/TargetAgeEditPage.vue
@@ -50,6 +50,8 @@ export default {
         if (!targetAge) return;
         await apiClient.patch(`/target_ages/${targetAgeId}`, {
           name: targetAge.name
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'TargetAgePage' })
       } catch {
@@ -60,7 +62,9 @@ export default {
       try {
         const apiClient = getApiClient()
         this.error = null
-        await apiClient.delete(`/target_ages/${targetAgeId}`)
+        await apiClient.delete(`/target_ages/${targetAgeId}`, {
+          withCredentials: true
+        })
         this.$router.push({ name: 'TargetAgePage' })
       } catch {
         this.error = '対象年齢を削除出来ませんでした。'

--- a/frontend/src/views/MakingIntroductions/TargetAgePage.vue
+++ b/frontend/src/views/MakingIntroductions/TargetAgePage.vue
@@ -33,6 +33,8 @@ export default {
         this.error = null
         await apiClient.post('/target_ages', {
           name: this.name
+        }, {
+          withCredentials: true
         })
         this.$router.push({ name: 'EventSettingPage' })
       } catch {

--- a/frontend/src/views/RegisterPage.vue
+++ b/frontend/src/views/RegisterPage.vue
@@ -90,7 +90,9 @@ export default {
         this.$store.commit('setUser', {
           name: this.name,
           email: user.email,
-          uid: user.uid
+          uid: res.headers['uid'],
+          'access-token': res.headers['access-token'],
+          client: res.headers['client']
         })
         this.$router.push({ name: 'HomePage' })
         return res

--- a/frontend/src/views/RegisterPage.vue
+++ b/frontend/src/views/RegisterPage.vue
@@ -94,6 +94,13 @@ export default {
           'access-token': res.headers['access-token'],
           client: res.headers['client']
         })
+        localStorage.setItem('currentUser', JSON.stringify({
+          name: this.name,
+          email: user.email,
+          uid: res.headers['uid'],
+          'access-token': res.headers['access-token'],
+          client: res.headers['client']
+        }))
         this.$router.push({ name: 'HomePage' })
         return res
       } catch (error) {

--- a/frontend/src/views/SignupPage.vue
+++ b/frontend/src/views/SignupPage.vue
@@ -57,7 +57,9 @@ export default {
         this.$store.commit('setUser', {
           name: user.displayName,
           email: user.email,
-          uid: user.uid
+          uid: res.headers['uid'],
+          'access-token': res.headers['access-token'],
+          client: res.headers['client']
         })
         this.$router.push({ name: 'HomePage' })
         return res

--- a/frontend/src/views/SignupPage.vue
+++ b/frontend/src/views/SignupPage.vue
@@ -61,6 +61,13 @@ export default {
           'access-token': res.headers['access-token'],
           client: res.headers['client']
         })
+        localStorage.setItem('currentUser', JSON.stringify({
+          name: user.displayName,
+          email: user.email,
+          uid: res.headers['uid'],
+          'access-token': res.headers['access-token'],
+          client: res.headers['client']
+        }))
         this.$router.push({ name: 'HomePage' })
         return res
       } catch (error) {


### PR DESCRIPTION
- フロントエンドからの認証付きリクエストが可能となるよう、axiosのリクエストに `withCredentials: true` を追加しました。
- それに対応するため、バックエンド側（Rails）の `config/initializers/cors.rb` に `credentials: true` を追加し、クッキーを用いた認証情報の送受信が許可されるよう設定を変更しました。
- これにより、Devise Token Auth によるセッションベースの認証がクロスオリジン環境でも正常に動作するようになります。
- FirebaseによるGoogle認証後、レスポンスヘッダーから `access-token`, `client`, `uid` を取得し、ローカルストレージに保存する処理を追加しました。これにより、セッション維持や再認証の簡略化が可能になります。


close https://github.com/toshinori-m/stay_connect/issues/261