### PR TITLE
チャットルーム一覧取得時のデータ参照ミスを修正（res.data → res.data.data）

### DIFF
--- a/frontend/src/views/ChatRoom/ChatRoomListPage.vue
+++ b/frontend/src/views/ChatRoom/ChatRoomListPage.vue
@@ -35,7 +35,7 @@ export default {
         const apiClient = getApiClient()
         this.error = null
         const res = await apiClient.get('/chat_rooms')
-        this.chat_rooms = res.data
+        this.chat_rooms = res.data.data
       } catch (error) {
         this.error = error.response ? error.response.data :'チャットルームを表示できませんでした。'
       }
@@ -45,7 +45,7 @@ export default {
         this.error = null
         const apiClient = getApiClient()
         const res = await apiClient.delete(`/chat_rooms/${chatRoomId}`)
-        this.chat_rooms = res.data
+        this.chat_rooms = res.data.data
         this.$router.push({ name: 'ChatRoomListPage' })
       } catch {
         this.error = 'チャットルームを削除出来ませんでした。'


### PR DESCRIPTION
## 概要
チャットルーム一覧取得処理で、APIレスポンスのネスト構造に対応できていなかったため、
チャットルームの id が undefined になり、削除操作時に意図しないURL（/chat_rooms/undefined）が送信されていた。

## 修正内容
- `getChatRoomList` メソッド内で `this.chat_rooms = res.data` を `res.data.data` に修正

close https://github.com/toshinori-m/stay_connect/issues/263