### PR TITLE
チーム登録API（POST /teams）を新規作成

### DIFF
--- a/backend-php/Dockerfile
+++ b/backend-php/Dockerfile
@@ -2,8 +2,12 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update --allow-insecure-repositories \
-    && apt-get install -y tzdata php8.1-cli php8.1-fpm php8.1-pgsql php8.1-mbstring curl unzip git \
+RUN apt-get update \
+    && apt-get install -y \
+    tzdata \
+    php-fpm \
+    php8.1-pgsql \
+    php8.1-mbstring \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/backend-php/Utils/team_util.php
+++ b/backend-php/Utils/team_util.php
@@ -1,0 +1,70 @@
+<?php
+class TeamUtil
+{
+  public static function validate(array $data, PDO $pdo): array {
+    $errors = [];
+
+    // enum変換: sex
+    $sexMap = [
+      'man' => 0,
+      'woman' => 1,
+      'mix' => 2,
+      'man_and_woman' => 3,
+    ];
+    $sexValue = $sexMap[$data['sex']] ?? null;
+
+    // 必須チェックと長さ制限
+    if (empty(trim($data['name'] ?? ''))) {
+      $errors['name'][] = "チーム名を入力してください。";
+    } elseif (mb_strlen($data['name']) > 255) {
+      $errors['name'][] = "チーム名は255文字以内で入力してください。";
+    }
+
+    if (empty(trim($data['area'] ?? ''))) {
+      $errors['area'][] = "活動地域を入力してください。";
+    } elseif (mb_strlen($data['area']) > 255) {
+      $errors['area'][] = "活動地域は255文字以内で入力してください。";
+    }
+
+    if ($sexValue === null) {
+      $errors['sex'][] = "性別を選択してください。";
+    }
+
+    if (empty(trim($data['track_record'] ?? ''))) {
+      $errors['track_record'][] = "活動実績を入力してください。";
+    } elseif (mb_strlen($data['track_record']) > 255) {
+      $errors['track_record'][] = "活動実績は255文字以内で入力してください。";
+    }
+
+    if (!empty($data['other_body']) && mb_strlen($data['other_body']) > 255) {
+      $errors['other_body'][] = "その他は255文字以内で入力してください。";
+    }
+
+    if (empty($data['sports_type_id'])) {
+      $errors['sports_type_id'][] = "競技を選択してください。";
+    }
+
+    if (empty($data['prefecture_id'])) {
+      $errors['prefecture_id'][] = "都道府県を選択してください。";
+    }
+
+    // sports_type_id のバリデーションと関連種目の存在確認
+    if (!empty($data['sports_type_id'])) {
+      $stmt = $pdo->prepare("SELECT COUNT(*) FROM sports_disciplines WHERE sports_type_id = :id");
+      $stmt->execute([':id' => $data['sports_type_id']]);
+      $count = $stmt->fetchColumn();
+
+      if ($count > 0 && empty($data['sports_discipline_ids'])) {
+        $errors['sports_discipline_ids'][] = "種目を選択してください。";
+      }
+    }
+
+    if (empty($data['target_age_ids']) || !is_array($data['target_age_ids']) || count($data['target_age_ids']) === 0) {
+      $errors['target_age_ids'][] = "対象年齢を選択してください。";
+    }
+
+    return [
+      'errors' => $errors
+    ];
+  }
+}

--- a/backend-php/model/recruitment.php
+++ b/backend-php/model/recruitment.php
@@ -1,17 +1,11 @@
 <?php
+require_once __DIR__ . '/team.php';
+
 class Recruitment
 {
   public static function validate(array $data, PDO $pdo): array {
     $errors = [];
-
-    // enum変換: sex
-    $sexMap = [
-      'man' => 0,
-      'woman' => 1,
-      'mix' => 2,
-      'man_and_woman' => 3,
-    ];
-    $sexValue = $sexMap[$data['sex']] ?? null;
+    $sexValue = Team::SEX_MAP[$data['sex']] ?? null;
 
     // sports_type_id のバリデーションと関連種目の存在確認
     if (empty($data['sports_type_id'])) {

--- a/backend-php/model/recruitment.php
+++ b/backend-php/model/recruitment.php
@@ -5,7 +5,15 @@ class Recruitment
 {
   public static function validate(array $data, PDO $pdo): array {
     $errors = [];
-    $sexValue = Team::SEX_MAP[$data['sex']] ?? null;
+    
+    // enum変換: sex
+    $sexMap = [
+      'man' => 0,
+      'woman' => 1,
+      'mix' => 2,
+      'man_and_woman' => 3,
+    ];
+    $sexValue = $sexMap[$data['sex']] ?? null;
 
     // sports_type_id のバリデーションと関連種目の存在確認
     if (empty($data['sports_type_id'])) {

--- a/backend-php/model/recruitment_disciplines.php
+++ b/backend-php/model/recruitment_disciplines.php
@@ -1,7 +1,8 @@
 <?php
 class RecruitmentDiscipline
 {
-  public static function insert(PDO $pdo, int $recruitmentId, array $disciplineIds, string $now): void {
+  public static function create(PDO $pdo, int $recruitmentId, array $disciplineIds, string $now): void
+  {
     if (empty($disciplineIds)) return;
 
     $placeholders = [];

--- a/backend-php/model/recruitment_target_ages.php
+++ b/backend-php/model/recruitment_target_ages.php
@@ -1,7 +1,8 @@
 <?php
 class RecruitmentTargetAge
 {
-  public static function insert(PDO $pdo, int $recruitmentId, array $targetAgeIds, string $now): void {
+  public static function create(PDO $pdo, int $recruitmentId, array $targetAgeIds, string $now): void
+  {
     if (empty($targetAgeIds)) return;
 
     $placeholders = [];

--- a/backend-php/model/team.php
+++ b/backend-php/model/team.php
@@ -1,0 +1,102 @@
+<?php
+class Team
+{
+  public static function validate(array $data, PDO $pdo): array {
+    $errors = [];
+
+    // enum変換: sex
+    $sexMap = [
+      'man' => 0,
+      'woman' => 1,
+      'mix' => 2,
+      'man_and_woman' => 3,
+    ];
+    $sexValue = $sexMap[$data['sex']] ?? null;
+
+    // 必須チェックと長さ制限
+    if (empty(trim($data['name'] ?? ''))) {
+      $errors['name'][] = "チーム名を入力してください。";
+    } elseif (mb_strlen($data['name']) > 255) {
+      $errors['name'][] = "チーム名は255文字以内で入力してください。";
+    }
+
+    if (empty(trim($data['area'] ?? ''))) {
+      $errors['area'][] = "活動地域を入力してください。";
+    } elseif (mb_strlen($data['area']) > 255) {
+      $errors['area'][] = "活動地域は255文字以内で入力してください。";
+    }
+
+    if ($sexValue === null) {
+      $errors['sex'][] = "性別を選択してください。";
+    }
+
+    if (empty(trim($data['track_record'] ?? ''))) {
+      $errors['track_record'][] = "活動実績を入力してください。";
+    } elseif (mb_strlen($data['track_record']) > 255) {
+      $errors['track_record'][] = "活動実績は255文字以内で入力してください。";
+    }
+
+    if (!empty($data['other_body']) && mb_strlen($data['other_body']) > 255) {
+      $errors['other_body'][] = "その他は255文字以内で入力してください。";
+    }
+
+    if (empty($data['sports_type_id'])) {
+      $errors['sports_type_id'][] = "競技を選択してください。";
+    }
+
+    if (empty($data['prefecture_id'])) {
+      $errors['prefecture_id'][] = "都道府県を選択してください。";
+    }
+
+    // sports_type_id のバリデーションと関連種目の存在確認
+    if (!empty($data['sports_type_id'])) {
+      $stmt = $pdo->prepare("SELECT COUNT(*) FROM sports_disciplines WHERE sports_type_id = :id");
+      $stmt->execute([':id' => $data['sports_type_id']]);
+      $count = $stmt->fetchColumn();
+
+      if ($count > 0 && empty($data['sports_discipline_ids'])) {
+        $errors['sports_discipline_ids'][] = "種目を選択してください。";
+      }
+    }
+
+    if (empty($data['target_age_ids']) || !is_array($data['target_age_ids']) || count($data['target_age_ids']) === 0) {
+      $errors['target_age_ids'][] = "対象年齢を選択してください。";
+    }
+
+    return [
+      'errors' => $errors,
+      'sexValue' => $sexValue
+    ];
+  }
+
+  public static function create(PDO $pdo, array $data, int $userId, int $sexValue, string $now): int {
+    $stmt = $pdo->prepare("
+      INSERT INTO teams (
+        user_id, name, area, sex,
+        track_record, other_body,
+        sports_type_id, prefecture_id,
+        created_at, updated_at
+      ) VALUES (
+        :user_id, :name, :area, :sex,
+        :track_record, :other_body,
+        :sports_type_id, :prefecture_id,
+        :created_at, :updated_at
+      )
+    ");
+
+    $stmt->execute([
+      ':user_id' => $userId,
+      ':name' => $data['name'],
+      ':area' => $data['area'],
+      ':sex' => $sexValue,
+      ':track_record' => $data['track_record'],
+      ':other_body' => $data['other_body'] ?? null,
+      ':sports_type_id' => $data['sports_type_id'],
+      ':prefecture_id' => $data['prefecture_id'],
+      ':created_at' => $now,
+      ':updated_at' => $now,
+    ]);
+
+    return (int)$pdo->lastInsertId();
+  }
+}

--- a/backend-php/model/team.php
+++ b/backend-php/model/team.php
@@ -99,4 +99,25 @@ class Team
 
     return (int)$pdo->lastInsertId();
   }
+
+  public static function fetchAllByUserId(PDO $pdo, int $userId, int $limit = 5): array {
+    $stmt = $pdo->prepare("SELECT id, name FROM teams WHERE user_id = :user_id ORDER BY id LIMIT :limit");
+    $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $stmt->execute();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+  }
+
+  public static function deleteByIdAndUserId(PDO $pdo, int $teamId, int $userId): bool {
+    $stmt = $pdo->prepare("DELETE FROM teams WHERE id = :id AND user_id = :user_id");
+    $stmt->execute([':id' => $teamId, ':user_id' => $userId]);
+    return $stmt->rowCount() > 0;
+  }
+
+  public static function findByIdAndUserId(PDO $pdo, int $teamId, int $userId): ?array {
+    $stmt = $pdo->prepare("SELECT id, name, sports_type_id, sex, area, prefecture_id, track_record, other_body FROM teams WHERE id = :id AND user_id = :user_id");
+    $stmt->execute([':id' => $teamId, ':user_id' => $userId]);
+    $result = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $result ?: null;
+  }
 }

--- a/backend-php/model/team.php
+++ b/backend-php/model/team.php
@@ -1,80 +1,14 @@
 <?php
 class Team
 {
-  public const SEX_MAP = [
-    'man' => 0,
-    'woman' => 1,
-    'mix' => 2,
-    'man_and_woman' => 3,
-  ];
-  
-  public static function validate(array $data, PDO $pdo): array {
-    $errors = [];
-    $sexValue = Team::SEX_MAP[$data['sex']] ?? null;
-
-    // 必須チェックと長さ制限
-    if (empty(trim($data['name'] ?? ''))) {
-      $errors['name'][] = "チーム名を入力してください。";
-    } elseif (mb_strlen($data['name']) > 255) {
-      $errors['name'][] = "チーム名は255文字以内で入力してください。";
-    }
-
-    if (empty(trim($data['area'] ?? ''))) {
-      $errors['area'][] = "活動地域を入力してください。";
-    } elseif (mb_strlen($data['area']) > 255) {
-      $errors['area'][] = "活動地域は255文字以内で入力してください。";
-    }
-
-    if ($sexValue === null) {
-      $errors['sex'][] = "性別を選択してください。";
-    }
-
-    if (empty(trim($data['track_record'] ?? ''))) {
-      $errors['track_record'][] = "活動実績を入力してください。";
-    } elseif (mb_strlen($data['track_record']) > 255) {
-      $errors['track_record'][] = "活動実績は255文字以内で入力してください。";
-    }
-
-    if (!empty($data['other_body']) && mb_strlen($data['other_body']) > 255) {
-      $errors['other_body'][] = "その他は255文字以内で入力してください。";
-    }
-
-    if (empty($data['sports_type_id'])) {
-      $errors['sports_type_id'][] = "競技を選択してください。";
-    }
-
-    if (empty($data['prefecture_id'])) {
-      $errors['prefecture_id'][] = "都道府県を選択してください。";
-    }
-
-    // sports_type_id のバリデーションと関連種目の存在確認
-    if (!empty($data['sports_type_id'])) {
-      $stmt = $pdo->prepare("SELECT COUNT(*) FROM sports_disciplines WHERE sports_type_id = :id");
-      $stmt->execute([':id' => $data['sports_type_id']]);
-      $count = $stmt->fetchColumn();
-
-      if ($count > 0 && empty($data['sports_discipline_ids'])) {
-        $errors['sports_discipline_ids'][] = "種目を選択してください。";
-      }
-    }
-
-    if (empty($data['target_age_ids']) || !is_array($data['target_age_ids']) || count($data['target_age_ids']) === 0) {
-      $errors['target_age_ids'][] = "対象年齢を選択してください。";
-    }
-
-    return [
-      'errors' => $errors
-    ];
-  }
-
   public static function create(PDO $pdo, array $data, int $userId, string $now): int {
-  $sexMap = [
-    'man' => 0,
-    'woman' => 1,
-    'mix' => 2,
-    'man_and_woman' => 3,
-  ];
-  $sexValue = $sexMap[$data['sex']] ?? null;
+    $sexMap = [
+      'man' => 0,
+      'woman' => 1,
+      'mix' => 2,
+      'man_and_woman' => 3,
+    ];
+    $sexValue = $sexMap[$data['sex']] ?? null;
 
     $stmt = $pdo->prepare("
       INSERT INTO teams (

--- a/backend-php/model/team.php
+++ b/backend-php/model/team.php
@@ -1,17 +1,16 @@
 <?php
 class Team
 {
+  public const SEX_MAP = [
+    'man' => 0,
+    'woman' => 1,
+    'mix' => 2,
+    'man_and_woman' => 3,
+  ];
+  
   public static function validate(array $data, PDO $pdo): array {
     $errors = [];
-
-    // enum変換: sex
-    $sexMap = [
-      'man' => 0,
-      'woman' => 1,
-      'mix' => 2,
-      'man_and_woman' => 3,
-    ];
-    $sexValue = $sexMap[$data['sex']] ?? null;
+    $sexValue = Team::SEX_MAP[$data['sex']] ?? null;
 
     // 必須チェックと長さ制限
     if (empty(trim($data['name'] ?? ''))) {

--- a/backend-php/model/team.php
+++ b/backend-php/model/team.php
@@ -63,12 +63,19 @@ class Team
     }
 
     return [
-      'errors' => $errors,
-      'sexValue' => $sexValue
+      'errors' => $errors
     ];
   }
 
-  public static function create(PDO $pdo, array $data, int $userId, int $sexValue, string $now): int {
+  public static function create(PDO $pdo, array $data, int $userId, string $now): int {
+  $sexMap = [
+    'man' => 0,
+    'woman' => 1,
+    'mix' => 2,
+    'man_and_woman' => 3,
+  ];
+  $sexValue = $sexMap[$data['sex']] ?? null;
+
     $stmt = $pdo->prepare("
       INSERT INTO teams (
         user_id, name, area, sex,

--- a/backend-php/model/team_disciplines.php
+++ b/backend-php/model/team_disciplines.php
@@ -1,0 +1,26 @@
+<?php
+class TeamDiscipline
+{
+  public static function insert(PDO $pdo, int $teamId, array $disciplineIds, string $now): void {
+    if (empty($disciplineIds)) return;
+
+    $placeholders = [];
+    $params = [];
+
+    foreach ($disciplineIds as $id) {
+      $placeholders[] = "(?, ?, ?, ?)";
+      $params[] = $teamId;
+      $params[] = $id;
+      $params[] = $now;
+      $params[] = $now;
+    }
+
+    $sql = "
+      INSERT INTO team_sports_disciplines
+        (team_id, sports_discipline_id, created_at, updated_at)
+      VALUES " . implode(", ", $placeholders);
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+  }
+}

--- a/backend-php/model/team_disciplines.php
+++ b/backend-php/model/team_disciplines.php
@@ -23,4 +23,15 @@ class TeamDiscipline
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
   }
+
+  public static function deleteByTeamId(PDO $pdo, int $teamId): void {
+    $stmt = $pdo->prepare("DELETE FROM team_sports_disciplines WHERE team_id = :team_id");
+    $stmt->execute([':team_id' => $teamId]);
+  }
+  
+  public static function getIdsByTeamId(PDO $pdo, int $teamId): array {
+    $stmt = $pdo->prepare("SELECT sports_discipline_id FROM team_sports_disciplines WHERE team_id = :team_id");
+    $stmt->execute([':team_id' => $teamId]);
+    return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'sports_discipline_id');
+  }
 }

--- a/backend-php/model/team_disciplines.php
+++ b/backend-php/model/team_disciplines.php
@@ -1,7 +1,8 @@
 <?php
 class TeamDiscipline
 {
-  public static function insert(PDO $pdo, int $teamId, array $disciplineIds, string $now): void {
+  public static function create(PDO $pdo, int $teamId, array $disciplineIds, string $now): void
+  {
     if (empty($disciplineIds)) return;
 
     $placeholders = [];

--- a/backend-php/model/team_target_ages.php
+++ b/backend-php/model/team_target_ages.php
@@ -1,0 +1,26 @@
+<?php
+class TeamTargetAge
+{
+  public static function insert(PDO $pdo, int $teamId, array $targetAgeIds, string $now): void {
+    if (empty($targetAgeIds)) return;
+
+    $placeholders = [];
+    $params = [];
+
+    foreach ($targetAgeIds as $id) {
+      $placeholders[] = "(?, ?, ?, ?)";
+      $params[] = $teamId;
+      $params[] = $id;
+      $params[] = $now;
+      $params[] = $now;
+    }
+
+    $sql = "
+      INSERT INTO team_target_ages
+        (team_id, target_age_id, created_at, updated_at)
+      VALUES " . implode(", ", $placeholders);
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+  }
+}

--- a/backend-php/model/team_target_ages.php
+++ b/backend-php/model/team_target_ages.php
@@ -23,4 +23,15 @@ class TeamTargetAge
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
   }
+
+  public static function deleteByTeamId(PDO $pdo, int $teamId): void {
+    $stmt = $pdo->prepare("DELETE FROM team_target_ages WHERE team_id = :team_id");
+    $stmt->execute([':team_id' => $teamId]);
+  }
+
+  public static function getIdsByTeamId(PDO $pdo, int $teamId): array {
+    $stmt = $pdo->prepare("SELECT target_age_id FROM team_target_ages WHERE team_id = :team_id");
+    $stmt->execute([':team_id' => $teamId]);
+    return array_column($stmt->fetchAll(PDO::FETCH_ASSOC), 'target_age_id');
+  }
 }

--- a/backend-php/model/team_target_ages.php
+++ b/backend-php/model/team_target_ages.php
@@ -1,7 +1,8 @@
 <?php
 class TeamTargetAge
 {
-  public static function insert(PDO $pdo, int $teamId, array $targetAgeIds, string $now): void {
+  public static function create(PDO $pdo, int $teamId, array $targetAgeIds, string $now): void
+  {
     if (empty($targetAgeIds)) return;
 
     $placeholders = [];

--- a/backend-php/public/index.php
+++ b/backend-php/public/index.php
@@ -18,10 +18,15 @@ $routes = [
     '/prefectures' => __DIR__ . '/../src/prefectures.php',
     '/target_ages' => __DIR__ . '/../src/target_ages.php',
     '/searches' => __DIR__ . '/../src/searches.php',
-    '/users/:uid' => __DIR__ . '/../src/users_show.php'
+    '/users/:uid' => __DIR__ . '/../src/users_show.php',
+    '/teams' => __DIR__ . '/../src/teams_index.php',
+    '/teams/:id' => __DIR__ . '/../src/teams_show.php'
   ],
   'PATCH' => [
     '/users/:id' => __DIR__ . '/../src/users_update.php'
+  ],
+  'DELETE' => [
+    '/teams/:id' => __DIR__ . '/../src/teams_delete.php',
   ]
 ];
 

--- a/backend-php/public/index.php
+++ b/backend-php/public/index.php
@@ -7,7 +7,9 @@ header("Content-Type: application/json; charset=UTF-8");
 
 $routes = [
   'POST' => [
-    '/users' => __DIR__ . '/../src/register.php'
+    '/users' => __DIR__ . '/../src/register.php',
+    '/recruitments' => __DIR__ . '/../src/recruitments_store.php',
+    '/teams' => __DIR__ . '/../src/teams_store.php'
   ],
   'GET' => [
     '/users/me' => __DIR__ . '/../src/users_me.php',

--- a/backend-php/src/recruitments_store.php
+++ b/backend-php/src/recruitments_store.php
@@ -49,15 +49,14 @@ try {
   $recruitmentId = Recruitment::create($pdo, $data, $userId, $sexValue, $startDate, $endDate, $now);
 
   // 中間テーブル登録
-  RecruitmentDiscipline::insert($pdo, $recruitmentId, $data['sports_discipline_ids'] ?? [], $now);
-  RecruitmentTargetAge::insert($pdo, $recruitmentId, $data['target_age_ids'] ?? [], $now);
+  RecruitmentDiscipline::create($pdo, $recruitmentId, $data['sports_discipline_ids'] ?? [], $now);
+  RecruitmentTargetAge::create($pdo, $recruitmentId, $data['target_age_ids'] ?? [], $now);
 
   $pdo->commit();
 
   http_response_code(201);
   echo json_encode(['message' => 'イベントが登録されました', 'recruitment_id' => $recruitmentId]);
   exit(0);
-
 } catch (PDOException $e) {
   handlePDOException($e);
 } catch (Exception $e) {

--- a/backend-php/src/teams_delete.php
+++ b/backend-php/src/teams_delete.php
@@ -38,7 +38,7 @@ try {
   $pdo->commit();
 
   if (!$deleted) {
-    http_response_code(403);
+    http_response_code(404);
     echo json_encode(['error' => '削除対象が存在しないか、権限がありません']);
     exit(1);
   }

--- a/backend-php/src/teams_delete.php
+++ b/backend-php/src/teams_delete.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/authenticate.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+require_once __DIR__ . '/../model/team.php';
+require_once __DIR__ . '/../model/team_disciplines.php';
+require_once __DIR__ . '/../model/team_target_ages.php';
+
+header('Content-Type: application/json');
+$uid = authenticate_uid();
+
+try {
+  $pdo = getPDO();
+  $user = findUserByUid($pdo, $uid);
+
+  if (!$user) {
+    http_response_code(401);
+    echo json_encode(['error' => 'ユーザーが存在しません']);
+    exit(1);
+  }
+
+  $teamId = $_GET['route_params'][0] ?? null;
+  if (!$teamId) {
+    http_response_code(400);
+    echo json_encode(['error' => 'チームIDが指定されていません']);
+    exit(1);
+  }
+
+  $pdo->beginTransaction();
+
+  // 中間テーブルを削除
+  TeamDiscipline::deleteByTeamId($pdo, $teamId);
+  TeamTargetAge::deleteByTeamId($pdo, $teamId);
+
+  // 所有権チェックを含めた削除
+  $deleted = Team::deleteByIdAndUserId($pdo, $teamId, $user['id']);
+
+  $pdo->commit();
+
+  if (!$deleted) {
+    http_response_code(403);
+    echo json_encode(['error' => '削除対象が存在しないか、権限がありません']);
+    exit(1);
+  }
+
+  // 削除後のチーム一覧を返却（最大5件）
+  $teams = Team::fetchAllByUserId($pdo, $user['id'], 5);
+  echo json_encode($teams);
+} catch (PDOException $e) {
+  $pdo->rollBack();
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/teams_index.php
+++ b/backend-php/src/teams_index.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/authenticate.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+require_once __DIR__ . '/../model/team.php';
+
+header('Content-Type: application/json');
+$uid = authenticate_uid();
+
+try {
+  $pdo = getPDO();
+  $user = findUserByUid($pdo, $uid);
+
+  if (!$user) {
+    http_response_code(401);
+    echo json_encode(['error' => 'ユーザーが存在しません']);
+    exit(1);
+  }
+
+  $teams = Team::fetchAllByUserId($pdo, $user['id'], 5); // 最大5件
+  echo json_encode(['data' => $teams]);
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/teams_show.php
+++ b/backend-php/src/teams_show.php
@@ -5,9 +5,11 @@ require_once __DIR__ . '/../lib/error_handler.php';
 require_once __DIR__ . '/../model/team.php';
 require_once __DIR__ . '/../model/team_disciplines.php';
 require_once __DIR__ . '/../model/team_target_ages.php';
+require_once __DIR__ . '/../model/team.php';
 
 header('Content-Type: application/json');
 $uid = authenticate_uid();
+
 
 try {
   $pdo = getPDO();
@@ -34,17 +36,11 @@ try {
     exit;
   }
 
-  $sexMap = [
-    1 => 'man',
-    2 => 'woman',
-    3 => 'mix',
-    4 => 'man_and_woman'
-  ];
-  $team['sex'] = $sexMap[$team['sex']] ?? '';
+  $team['sex'] = array_flip(Team::SEX_MAP)[$team['sex']] ?? '';
 
   // 中間テーブルのIDも取得
-  $team['sports_discipline'] = TeamDiscipline::getIdsByTeamId($pdo, $teamId);
-  $team['target_age'] = TeamTargetAge::getIdsByTeamId($pdo, $teamId);
+  $team['sports_disciplines'] = TeamDiscipline::getIdsByTeamId($pdo, $teamId);
+  $team['target_ages'] = TeamTargetAge::getIdsByTeamId($pdo, $teamId);
 
   echo json_encode(['data' => $team]);
 } catch (PDOException $e) {

--- a/backend-php/src/teams_show.php
+++ b/backend-php/src/teams_show.php
@@ -36,7 +36,13 @@ try {
     exit;
   }
 
-  $team['sex'] = array_flip(Team::SEX_MAP)[$team['sex']] ?? '';
+  $sexMap = [
+    0 => 'man',
+    1 => 'woman',
+    2 => 'mix',
+    3 => 'man_and_woman'
+  ];
+  $team['sex'] = $sexMap[$team['sex']] ?? '';
 
   // 中間テーブルのIDも取得
   $team['sports_disciplines'] = TeamDiscipline::getIdsByTeamId($pdo, $teamId);

--- a/backend-php/src/teams_show.php
+++ b/backend-php/src/teams_show.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/authenticate.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+require_once __DIR__ . '/../model/team.php';
+require_once __DIR__ . '/../model/team_disciplines.php';
+require_once __DIR__ . '/../model/team_target_ages.php';
+
+header('Content-Type: application/json');
+$uid = authenticate_uid();
+
+try {
+  $pdo = getPDO();
+  $user = findUserByUid($pdo, $uid);
+
+  if (!$user) {
+    http_response_code(401);
+    echo json_encode(['error' => 'ユーザーが存在しません']);
+    exit;
+  }
+
+  $teamId = $_GET['route_params'][0] ?? null;
+  if (!$teamId) {
+    http_response_code(400);
+    echo json_encode(['error' => 'チームIDが指定されていません']);
+    exit;
+  }
+
+  // ユーザーが所有するチームかを確認して取得
+  $team = Team::findByIdAndUserId($pdo, $teamId, $user['id']);
+  if (!$team) {
+    http_response_code(404);
+    echo json_encode(['error' => 'チームが見つかりません']);
+    exit;
+  }
+
+  $sexMap = [
+    1 => 'man',
+    2 => 'woman',
+    3 => 'mix',
+    4 => 'man_and_woman'
+  ];
+  $team['sex'] = $sexMap[$team['sex']] ?? '';
+
+  // 中間テーブルのIDも取得
+  $team['sports_discipline'] = TeamDiscipline::getIdsByTeamId($pdo, $teamId);
+  $team['target_age'] = TeamTargetAge::getIdsByTeamId($pdo, $teamId);
+
+  echo json_encode(['data' => $team]);
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/teams_store.php
+++ b/backend-php/src/teams_store.php
@@ -1,0 +1,62 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/authenticate.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+require_once __DIR__ . '/../model/team.php';
+require_once __DIR__ . '/../model/team_disciplines.php';
+require_once __DIR__ . '/../model/team_target_ages.php';
+
+header('Content-Type: application/json');
+$uid = authenticate_uid();
+
+try {
+  $pdo = getPDO();
+  $user = findUserByUid($pdo, $uid);
+
+  if (!$user) {
+    http_response_code(401);
+    echo json_encode(['error' => ['user' => ['ユーザーが存在しません']]]);
+    exit(1);
+  }
+
+  $input = json_decode(file_get_contents("php://input"), true);
+  if (!$input || !isset($input['team'])) {
+    http_response_code(400);
+    echo json_encode(['error' => ['base' => ['リクエスト形式が不正です']]]);
+    exit(1);
+  }
+
+  $data = $input['team'];
+  $now = (new DateTime())->format('Y-m-d H:i:s');
+
+  // バリデーション
+  $validation = Team::validate($data, $pdo);
+  $errors = $validation['errors'];
+  $sexValue = $validation['sexValue'];
+
+  if (!empty($errors)) {
+    http_response_code(422);
+    echo json_encode(['error' => $errors]);
+    exit(1);
+  }
+
+  $pdo->beginTransaction();
+
+  // チーム登録
+  $teamId = Team::create($pdo, $data, $user['id'], $sexValue, $now);
+
+  // 中間テーブル登録
+  TeamDiscipline::insert($pdo, $teamId, $data['sports_discipline_ids'] ?? [], $now);
+  TeamTargetAge::insert($pdo, $teamId, $data['target_age_ids'] ?? [], $now);
+
+  $pdo->commit();
+
+  http_response_code(201);
+  echo json_encode(['message' => 'チームが登録されました', 'team_id' => $teamId]);
+  exit(0);
+
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}

--- a/backend-php/src/teams_store.php
+++ b/backend-php/src/teams_store.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../lib/error_handler.php';
 require_once __DIR__ . '/../model/team.php';
 require_once __DIR__ . '/../model/team_disciplines.php';
 require_once __DIR__ . '/../model/team_target_ages.php';
+require_once __DIR__ . '/../Utils/team_util.php';
 
 header('Content-Type: application/json');
 $uid = authenticate_uid();
@@ -30,7 +31,7 @@ try {
   $now = (new DateTime())->format('Y-m-d H:i:s');
 
   // バリデーション
-  $validation = Team::validate($data, $pdo);
+  $validation = TeamUtil::validate($data, $pdo);
   $errors = $validation['errors'];
 
   if (!empty($errors)) {

--- a/backend-php/src/teams_store.php
+++ b/backend-php/src/teams_store.php
@@ -32,7 +32,6 @@ try {
   // バリデーション
   $validation = Team::validate($data, $pdo);
   $errors = $validation['errors'];
-  $sexValue = $validation['sexValue'];
 
   if (!empty($errors)) {
     http_response_code(422);
@@ -43,18 +42,17 @@ try {
   $pdo->beginTransaction();
 
   // チーム登録
-  $teamId = Team::create($pdo, $data, $user['id'], $sexValue, $now);
+  $teamId = Team::create($pdo, $data, $user['id'], $now);
 
   // 中間テーブル登録
-  TeamDiscipline::insert($pdo, $teamId, $data['sports_discipline_ids'] ?? [], $now);
-  TeamTargetAge::insert($pdo, $teamId, $data['target_age_ids'] ?? [], $now);
+  TeamDiscipline::create($pdo, $teamId, $data['sports_discipline_ids'] ?? [], $now);
+  TeamTargetAge::create($pdo, $teamId, $data['target_age_ids'] ?? [], $now);
 
   $pdo->commit();
 
   http_response_code(201);
   echo json_encode(['message' => 'チームが登録されました', 'team_id' => $teamId]);
   exit(0);
-
 } catch (PDOException $e) {
   handlePDOException($e);
 } catch (Exception $e) {


### PR DESCRIPTION
## 概要
- チーム情報を登録するためのAPI（`POST /teams`）をPHPで新規実装しました。

## 変更内容
- `src/teams_store.php` を新規作成し、下記の処理を実装：
  - Firebase UID によるユーザー認証（`authenticate_uid()` を使用）
  - 入力バリデーション（必須項目、文字数制限、競技に応じた種目のバリデーションなど）
  - `teams` テーブルへの登録
  - 中間テーブル（`team_sports_disciplines`, `team_target_ages`）への登録
- `public/index.php` にルーティングを追加（`POST /teams`）
- `model/team.php`, `team_disciplines.php`, `team_target_ages.php` を新規作成
- 種目（`sports_discipline_ids`）は、該当する競技の種目が存在する場合のみ選択必須としています
- `authenticate_uid()` と併せて `findUserByUid()` を共通ロジックとして利用
- 中間テーブル登録はループ処理ではなくバルクインサートで実装し、DB負荷を軽減
- Dockerfile を修正（必要なPHPモジュール）

## 変更の確認手順
- 新規ユーザー登録時、もしくはログイン時はのhome画面は下のように表示しています。
- 画像のように下の項目を実行して下さい。
   1. 赤丸で囲った「チーム紹介一覧」を選択します。
![新規メモ](https://github.com/user-attachments/assets/d38687f1-ecd9-42e9-8fec-c1bb8336882a)

   2. 下のチーム紹介一覧画面へ遷移するので赤丸で囲った「チーム紹介作成（最大5チームまで）」を選択します。
![新規メモ](https://github.com/user-attachments/assets/4c2e3a04-53be-4bd6-a287-9e286906619a)

   3. 下のチーム紹介作成画面へ遷移するので、各項目を選択および入力を行い「登録」ボタンを押します。
      - 選択項目: 競技名（種目（複数可））、都道府県、対象年齢（複数可）、性別、開始日付、終了日付
      - 入力項目: イベント名、イベントURL、イベント開催場所、募集チーム数（半角数字）、イベント目的、その他
![新規メモ](https://github.com/user-attachments/assets/d843f08b-2bac-4299-b449-b2e765dbf4d3)

   4. ターミナルにて下の項目1~5を実行し登録の確認を行います。
1. $ docker exec -it stay_connect-db-1 bash
2. root@0400252bf828:/# psql -U postgres
3. postgres=# \l
List of databases
```
| Name              | Owner    | Encoding | Locale Provider | Collate     | Ctype       | Locale | ICU Rules | Access privileges                     |
|-------------------|----------|----------|------------------|-------------|-------------|--------|-----------|---------------------------------------|
| myapp_development | postgres | UTF8     | libc             | en_US.utf8  | en_US.utf8  |        |           |                                       |
| myapp_test        | postgres | UTF8     | libc             | en_US.utf8  | en_US.utf8  |        |           |                                       |
| postgres          | postgres | UTF8     | libc             | en_US.utf8  | en_US.utf8  |        |           |                                       |
| template0         | postgres | UTF8     | libc             | en_US.utf8  | en_US.utf8  |        |           | =c/postgres  
                                                                                   postgres=CTc/postgres |
| template1         | postgres | UTF8     | libc             | en_US.utf8  | en_US.utf8  |        |           | =c/postgres  
                                                                                   postgres=CTc/postgres |

```

4. postgres=# \c myapp_development
5. myapp_development=# SELECT * FROM teams;
```
| id |   name   |   area   | sex | track_record | user_id | sports_type_id | prefecture_id | other_body |     created_at      |     updated_at      |
|----|----------|----------|-----|--------------|---------|----------------|---------------|------------|---------------------|---------------------|
|  2 | チーム名     | 活動地域 |  1  | 活動実績         |    6    |       1        |       3       | その他       | 2025-07-03 07:26:40 | 2025-07-03 07:26:40 |
```

close https://github.com/toshinori-m/stay_connect/issues/260