### PR TITLE
WIP: チーム紹介情報を更新するAPI（PATCH /teams/:id）の実装

### DIFF
--- a/backend-php/lib/formdata_parser.php
+++ b/backend-php/lib/formdata_parser.php
@@ -39,13 +39,27 @@ function parseMultipartFormData(string $rawData, string $boundary): array
       // ファイルの場合は一時ファイルとして保存
       $tmpPath = '/tmp/' . uniqid('upload_', true) . '_' . basename($filename);
       file_put_contents($tmpPath, rtrim($body, "\r\n"));
+
       $parsed[$name] = [
         'filename' => $filename,
         'tmp_path' => $tmpPath,
       ];
-    } else {
-      $parsed[$name] = rtrim($body, "\r\n");
+      continue;
     }
+
+    // ファイルでなければテキストデータとして処理
+    $value = rtrim($body, "\r\n");
+
+    if (!isset($parsed[$name])) {
+      $parsed[$name] = $value;
+      continue;
+    }
+
+    if (!is_array($parsed[$name])) {
+      $parsed[$name] = [$parsed[$name]];
+    }
+
+    $parsed[$name][] = $value;
   }
 
   return $parsed;

--- a/backend-php/model/recruitment.php
+++ b/backend-php/model/recruitment.php
@@ -1,17 +1,11 @@
 <?php
+require_once __DIR__ . '/team.php';
+
 class Recruitment
 {
   public static function validate(array $data, PDO $pdo): array {
     $errors = [];
-
-    // enum変換: sex
-    $sexMap = [
-      'man' => 0,
-      'woman' => 1,
-      'mix' => 2,
-      'man_and_woman' => 3,
-    ];
-    $sexValue = $sexMap[$data['sex']] ?? null;
+    $sexValue = Team::SEX_MAP[$data['sex']] ?? null;
 
     // sports_type_id のバリデーションと関連種目の存在確認
     if (empty($data['sports_type_id'])) {

--- a/backend-php/model/recruitment.php
+++ b/backend-php/model/recruitment.php
@@ -62,7 +62,9 @@ class Recruitment
     ];
   }
 
-  public static function create(PDO $pdo, array $data, int $userId, int $sexValue, DateTime $startDate, DateTime $endDate, string $now): int {
+  public static function create(PDO $pdo, array $data, int $userId, int $sexValue, DateTime $startDate, DateTime $endDate, $now = null): int {
+    $now = $now ?? date('Y-m-d H:i:s');
+
     $stmt = $pdo->prepare("
       INSERT INTO recruitments (
         user_id, sports_type_id, prefecture_id,

--- a/backend-php/model/recruitment_disciplines.php
+++ b/backend-php/model/recruitment_disciplines.php
@@ -1,13 +1,14 @@
 <?php
 class RecruitmentDiscipline
 {
-  public static function insert(PDO $pdo, int $recruitmentId, array $disciplineIds, string $now): void {
+  public static function create(PDO $pdo, int $recruitmentId, array $disciplineIds, $now = null): void {
     if (empty($disciplineIds)) return;
 
+    $now = $now ?? date('Y-m-d H:i:s');
     $placeholders = [];
     $params = [];
 
-    foreach ($disciplineIds as $index => $id) {
+    foreach ($disciplineIds as $id) {
       $placeholders[] = "(?, ?, ?, ?)";
       $params[] = $recruitmentId;
       $params[] = $id;

--- a/backend-php/model/recruitment_target_ages.php
+++ b/backend-php/model/recruitment_target_ages.php
@@ -1,13 +1,14 @@
 <?php
 class RecruitmentTargetAge
 {
-  public static function insert(PDO $pdo, int $recruitmentId, array $targetAgeIds, string $now): void {
+  public static function create(PDO $pdo, int $recruitmentId, array $targetAgeIds, $now = null): void {
     if (empty($targetAgeIds)) return;
 
+    $now = $now ?? date('Y-m-d H:i:s');
     $placeholders = [];
     $params = [];
 
-    foreach ($targetAgeIds as $index => $id) {
+    foreach ($targetAgeIds as $id) {
       $placeholders[] = "(?, ?, ?, ?)";
       $params[] = $recruitmentId;
       $params[] = $id;

--- a/backend-php/model/team.php
+++ b/backend-php/model/team.php
@@ -119,4 +119,31 @@ class Team
     $result = $stmt->fetch(PDO::FETCH_ASSOC);
     return $result ?: null;
   }
+
+  public static function update(PDO $pdo, int $teamId, array $data, int $sexValue, string $now): void {
+    $stmt = $pdo->prepare("
+      UPDATE teams SET
+        name = :name,
+        area = :area,
+        sex = :sex,
+        track_record = :track_record,
+        other_body = :other_body,
+        sports_type_id = :sports_type_id,
+        prefecture_id = :prefecture_id,
+        updated_at = :updated_at
+      WHERE id = :id
+    ");
+
+    $stmt->execute([
+      ':name' => $data['name'],
+      ':area' => $data['area'],
+      ':sex' => $sexValue,
+      ':track_record' => $data['track_record'],
+      ':other_body' => $data['other_body'] ?? null,
+      ':sports_type_id' => $data['sports_type_id'],
+      ':prefecture_id' => $data['prefecture_id'],
+      ':updated_at' => $now,
+      ':id' => $teamId
+    ]);
+  }
 }

--- a/backend-php/model/team.php
+++ b/backend-php/model/team.php
@@ -68,7 +68,9 @@ class Team
     ];
   }
 
-  public static function create(PDO $pdo, array $data, int $userId, int $sexValue, string $now): int {
+  public static function create(PDO $pdo, array $data, int $userId, int $sexValue, $now = null): int {
+    $now = $now ?? date('Y-m-d H:i:s');
+
     $stmt = $pdo->prepare("
       INSERT INTO teams (
         user_id, name, area, sex,
@@ -120,7 +122,9 @@ class Team
     return $result ?: null;
   }
 
-  public static function update(PDO $pdo, int $teamId, array $data, int $sexValue, string $now): void {
+  public static function update(PDO $pdo, int $teamId, array $data, int $sexValue, $now = null): void {
+    $now = $now ?? date('Y-m-d H:i:s');
+
     $stmt = $pdo->prepare("
       UPDATE teams SET
         name = :name,

--- a/backend-php/model/team.php
+++ b/backend-php/model/team.php
@@ -1,17 +1,16 @@
 <?php
 class Team
 {
+  public const SEX_MAP = [
+    'man' => 0,
+    'woman' => 1,
+    'mix' => 2,
+    'man_and_woman' => 3,
+  ];
+  
   public static function validate(array $data, PDO $pdo): array {
     $errors = [];
-
-    // enum変換: sex
-    $sexMap = [
-      'man' => 0,
-      'woman' => 1,
-      'mix' => 2,
-      'man_and_woman' => 3,
-    ];
-    $sexValue = $sexMap[$data['sex']] ?? null;
+    $sexValue = Team::SEX_MAP[$data['sex']] ?? null;
 
     // 必須チェックと長さ制限
     if (empty(trim($data['name'] ?? ''))) {

--- a/backend-php/model/team_disciplines.php
+++ b/backend-php/model/team_disciplines.php
@@ -1,9 +1,10 @@
 <?php
 class TeamDiscipline
 {
-  public static function insert(PDO $pdo, int $teamId, array $disciplineIds, string $now): void {
+  public static function create(PDO $pdo, int $teamId, array $disciplineIds, $now = null): void {
     if (empty($disciplineIds)) return;
 
+    $now = $now ?? date('Y-m-d H:i:s');
     $placeholders = [];
     $params = [];
 

--- a/backend-php/model/team_target_ages.php
+++ b/backend-php/model/team_target_ages.php
@@ -1,9 +1,10 @@
 <?php
 class TeamTargetAge
 {
-  public static function insert(PDO $pdo, int $teamId, array $targetAgeIds, string $now): void {
+  public static function create(PDO $pdo, int $teamId, array $targetAgeIds, $now = null): void {
     if (empty($targetAgeIds)) return;
 
+    $now = $now ?? date('Y-m-d H:i:s');
     $placeholders = [];
     $params = [];
 

--- a/backend-php/model/user.php
+++ b/backend-php/model/user.php
@@ -9,8 +9,10 @@ class User
     return $user ?: null;
   }
 
-  public static function update(PDO $pdo, int $id, array $data): void
+  public static function update(PDO $pdo, int $id, array $data, $now = null): void
   {
+    $now = $now ?? date('Y-m-d H:i:s');
+
     $sql = "
       UPDATE users SET
         name = :name,
@@ -37,7 +39,7 @@ class User
     $stmt->bindValue(':sex', $data['sex'], PDO::PARAM_INT);
     $stmt->bindValue(':self_introduction', $data['self_introduction']);
     $stmt->bindValue(':email_notification', $data['email_notification'], PDO::PARAM_BOOL);
-    $stmt->bindValue(':updated_at', (new DateTime())->format('Y-m-d H:i:s'));
+    $stmt->bindValue(':updated_at', $now);
     $stmt->bindValue(':id', $id, PDO::PARAM_INT);
 
     if ($data['image']) {

--- a/backend-php/public/index.php
+++ b/backend-php/public/index.php
@@ -23,7 +23,8 @@ $routes = [
     '/teams/:id' => __DIR__ . '/../src/teams_show.php'
   ],
   'PATCH' => [
-    '/users/:id' => __DIR__ . '/../src/users_update.php'
+    '/users/:id' => __DIR__ . '/../src/users_update.php',
+    '/teams/:id' => __DIR__ . '/../src/teams_update.php'
   ],
   'DELETE' => [
     '/teams/:id' => __DIR__ . '/../src/teams_delete.php',

--- a/backend-php/src/recruitments_store.php
+++ b/backend-php/src/recruitments_store.php
@@ -19,7 +19,7 @@ try {
     exit(1);
   }
 
-  $now = (new DateTime())->format('Y-m-d H:i:s');
+  $now = $now ?? date('Y-m-d H:i:s');
   $userId = $user['id'];
   $input = json_decode(file_get_contents("php://input"), true);
 
@@ -46,11 +46,11 @@ try {
   $pdo->beginTransaction();
 
   // メインテーブル登録
-  $recruitmentId = Recruitment::create($pdo, $data, $userId, $sexValue, $startDate, $endDate, $now);
+  $recruitmentId = Recruitment::create($pdo, $data, $userId, $sexValue, $startDate, $endDate);
 
   // 中間テーブル登録
-  RecruitmentDiscipline::insert($pdo, $recruitmentId, $data['sports_discipline_ids'] ?? [], $now);
-  RecruitmentTargetAge::insert($pdo, $recruitmentId, $data['target_age_ids'] ?? [], $now);
+  RecruitmentDiscipline::create($pdo, $recruitmentId, $data['sports_discipline_ids'] ?? []);
+  RecruitmentTargetAge::create($pdo, $recruitmentId, $data['target_age_ids'] ?? []);
 
   $pdo->commit();
 

--- a/backend-php/src/teams_delete.php
+++ b/backend-php/src/teams_delete.php
@@ -38,7 +38,7 @@ try {
   $pdo->commit();
 
   if (!$deleted) {
-    http_response_code(403);
+    http_response_code(404);
     echo json_encode(['error' => '削除対象が存在しないか、権限がありません']);
     exit(1);
   }

--- a/backend-php/src/teams_show.php
+++ b/backend-php/src/teams_show.php
@@ -5,9 +5,11 @@ require_once __DIR__ . '/../lib/error_handler.php';
 require_once __DIR__ . '/../model/team.php';
 require_once __DIR__ . '/../model/team_disciplines.php';
 require_once __DIR__ . '/../model/team_target_ages.php';
+require_once __DIR__ . '/../model/team.php';
 
 header('Content-Type: application/json');
 $uid = authenticate_uid();
+
 
 try {
   $pdo = getPDO();
@@ -34,13 +36,7 @@ try {
     exit;
   }
 
-  $sexMap = [
-    1 => 'man',
-    2 => 'woman',
-    3 => 'mix',
-    4 => 'man_and_woman'
-  ];
-  $team['sex'] = $sexMap[$team['sex']] ?? '';
+  $team['sex'] = array_flip(Team::SEX_MAP)[$team['sex']] ?? '';
 
   // 中間テーブルのIDも取得
   $team['sports_discipline'] = TeamDiscipline::getIdsByTeamId($pdo, $teamId);

--- a/backend-php/src/teams_show.php
+++ b/backend-php/src/teams_show.php
@@ -39,8 +39,8 @@ try {
   $team['sex'] = array_flip(Team::SEX_MAP)[$team['sex']] ?? '';
 
   // 中間テーブルのIDも取得
-  $team['sports_discipline'] = TeamDiscipline::getIdsByTeamId($pdo, $teamId);
-  $team['target_age'] = TeamTargetAge::getIdsByTeamId($pdo, $teamId);
+  $team['sports_disciplines'] = TeamDiscipline::getIdsByTeamId($pdo, $teamId);
+  $team['target_ages'] = TeamTargetAge::getIdsByTeamId($pdo, $teamId);
 
   echo json_encode(['data' => $team]);
 } catch (PDOException $e) {

--- a/backend-php/src/teams_store.php
+++ b/backend-php/src/teams_store.php
@@ -27,7 +27,6 @@ try {
   }
 
   $data = $input['team'];
-  $now = (new DateTime())->format('Y-m-d H:i:s');
 
   // バリデーション
   $validation = Team::validate($data, $pdo);
@@ -43,11 +42,11 @@ try {
   $pdo->beginTransaction();
 
   // チーム登録
-  $teamId = Team::create($pdo, $data, $user['id'], $sexValue, $now);
+  $teamId = Team::create($pdo, $data, $user['id'], $sexValue);
 
   // 中間テーブル登録
-  TeamDiscipline::insert($pdo, $teamId, $data['sports_discipline_ids'] ?? [], $now);
-  TeamTargetAge::insert($pdo, $teamId, $data['target_age_ids'] ?? [], $now);
+  TeamDiscipline::create($pdo, $teamId, $data['sports_discipline_ids'] ?? []);
+  TeamTargetAge::create($pdo, $teamId, $data['target_age_ids'] ?? []);
 
   $pdo->commit();
 

--- a/backend-php/src/teams_update.php
+++ b/backend-php/src/teams_update.php
@@ -65,8 +65,6 @@ try {
     $data['target_age_ids'] = [$data['target_age_ids']];
   }
 
-  $now = (new DateTime())->format('Y-m-d H:i:s');
-
   $validation = Team::validate($data, $pdo);
   $errors = $validation['errors'];
   $sexValue = $validation['sexValue'];
@@ -79,11 +77,11 @@ try {
 
   $pdo->beginTransaction();
 
-  Team::update($pdo, $teamId, $data, $sexValue, $now);
+  Team::update($pdo, $teamId, $data, $sexValue);
   TeamDiscipline::deleteByTeamId($pdo, $teamId);
-  TeamDiscipline::insert($pdo, $teamId, $data['sports_discipline_ids'], $now);
+  TeamDiscipline::create($pdo, $teamId, $data['sports_discipline_ids']);
   TeamTargetAge::deleteByTeamId($pdo, $teamId);
-  TeamTargetAge::insert($pdo, $teamId, $data['target_age_ids'], $now);
+  TeamTargetAge::create($pdo, $teamId, $data['target_age_ids']);
 
   $pdo->commit();
 

--- a/backend-php/src/teams_update.php
+++ b/backend-php/src/teams_update.php
@@ -1,0 +1,98 @@
+<?php
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/authenticate.php';
+require_once __DIR__ . '/../lib/error_handler.php';
+require_once __DIR__ . '/../lib/formdata_parser.php';
+require_once __DIR__ . '/../model/team.php';
+require_once __DIR__ . '/../model/team_disciplines.php';
+require_once __DIR__ . '/../model/team_target_ages.php';
+
+header('Content-Type: application/json');
+$uid = authenticate_uid();
+
+try {
+  $pdo = getPDO();
+  $user = findUserByUid($pdo, $uid);
+
+  if (!$user) {
+    http_response_code(401);
+    echo json_encode(['error' => 'ユーザーが存在しません']);
+    exit;
+  }
+
+  $teamId = $_GET['route_params'][0] ?? null;
+  if (!$teamId) {
+    http_response_code(400);
+    echo json_encode(['error' => 'チームIDが指定されていません']);
+    exit;
+  }
+
+  $team = Team::findByIdAndUserId($pdo, $teamId, $user['id']);
+  if (!$team) {
+    http_response_code(404);
+    echo json_encode(['error' => 'チームが見つかりません']);
+    exit;
+  }
+
+  // multipart/form-data 対応：rawデータをパース
+  $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+  if (!preg_match('/boundary=(.*)$/', $contentType, $matches)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'boundary が見つかりません']);
+    exit;
+  }
+  $boundary = $matches[1];
+  $rawData = file_get_contents('php://input');
+  $parsed = parseMultipartFormData($rawData, $boundary);
+
+  // team[...] の形式から抽出
+  $data = [];
+  foreach ($parsed as $key => $val) {
+    if (preg_match('/^team\[(.+?)\]$/', $key, $m)) {
+      $data[$m[1]] = $val;
+    }
+  }
+
+  // 配列項目の取得（複数選択）
+  $data['sports_discipline_ids'] = $parsed['team[sports_discipline_ids][]'] ?? [];
+  $data['target_age_ids'] = $parsed['team[target_age_ids][]'] ?? [];
+
+  // 単一値が string の場合、配列に変換
+  if (!is_array($data['sports_discipline_ids'])) {
+    $data['sports_discipline_ids'] = [$data['sports_discipline_ids']];
+  }
+  if (!is_array($data['target_age_ids'])) {
+    $data['target_age_ids'] = [$data['target_age_ids']];
+  }
+
+  $now = (new DateTime())->format('Y-m-d H:i:s');
+
+  $validation = Team::validate($data, $pdo);
+  $errors = $validation['errors'];
+  $sexValue = $validation['sexValue'];
+
+  if (!empty($errors)) {
+    http_response_code(422);
+    echo json_encode(['error' => $errors]);
+    exit;
+  }
+
+  $pdo->beginTransaction();
+
+  Team::update($pdo, $teamId, $data, $sexValue, $now);
+  TeamDiscipline::deleteByTeamId($pdo, $teamId);
+  TeamDiscipline::insert($pdo, $teamId, $data['sports_discipline_ids'], $now);
+  TeamTargetAge::deleteByTeamId($pdo, $teamId);
+  TeamTargetAge::insert($pdo, $teamId, $data['target_age_ids'], $now);
+
+  $pdo->commit();
+
+  http_response_code(200);
+  echo json_encode(['message' => 'チーム情報を更新しました']);
+  exit;
+
+} catch (PDOException $e) {
+  handlePDOException($e);
+} catch (Exception $e) {
+  handleException($e);
+}


### PR DESCRIPTION
## 概要
既存のチーム紹介情報を編集・更新するためのAPI（PATCH /teams/:id）を新たに実装しました。
React側から送信される FormData 形式のリクエストに対応しています。
create や update メソッドで使用していた `$now` 引数について、必須ではなく省略可能にし、未指定時は `DateTime` により現在時刻を自動で設定するよう修正しました。

## 主な変更点
- `src/teams_update.php` を新規作成
  - Firebase UID によるユーザー認証
  - チーム所有者の確認（user_id と team_id の一致チェック）
  - `multipart/form-data` のリクエストボディをパース
  - `teams` テーブルのデータ更新処理を実装
  - 中間テーブル（`team_sports_disciplines`, `team_target_ages`）の削除→再登録処理
  - バリデーション（チーム名、活動地域、性別、実績など）

- `parseMultipartFormData()` を配列対応（`team[xxx_ids][]`）できるように拡張
- `Team::update()` メソッドを新規追加
- `$now = null` をデフォルト引数として追加
- `$now === null` の場合に `DateTime` を使って現在時刻を設定
- `Team`, `User`, `RecruitmentDiscipline` など複数のクラスで共通対応

## 変更の確認手順
- 新規ユーザー登録時、もしくはログイン時はのhome画面は下のように表示しています。
- 画像のように下の項目を実行して下さい。
   1. 赤丸で囲った「チーム紹介一覧」を選択します。
![新規メモ](https://github.com/user-attachments/assets/a976dddc-7705-43b5-808c-15273e2b28e7)

   2. チーム紹介一覧画面へ遷移するので、変更したいチーム名の赤枠の「編集」を選択します。
![新規メモ](https://github.com/user-attachments/assets/8d1d247a-d9ac-44a0-88e1-f192216d2c0b)

   3. チーム紹介編集画面へ遷移するので、必要な箇所を修正し赤枠の「更新」を選択します。
![新規メモ](https://github.com/user-attachments/assets/fa354174-d8ac-4fb6-9212-94fe45cde10e)

close https://github.com/toshinori-m/stay_connect/issues/268